### PR TITLE
[feat] Separate user model into auth/oauth and user models

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,6 +6,8 @@ from decouple import config as decouple_config
 from api.v1.models.user import User, WaitlistUser
 from api.v1.models.org import Organization
 from api.v1.models.profile import Profile
+from api.v1.models.auth import AuthUser
+from api.v1.models.oauth import OAuthUser
 from api.v1.models.product import Product
 from api.v1.models.base import Base
 from api.v1.models.subscription import Subscription

--- a/api/v1/models/auth.py
+++ b/api/v1/models/auth.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+""" Auth User data model
+"""
+from sqlalchemy import (
+    Column,
+    String,
+    CheckConstraint,
+    ForeignKey,
+)
+from sqlalchemy.orm import relationship
+from api.v1.models.base import Base
+import bcrypt
+from uuid_extensions import uuid7
+from sqlalchemy.dialects.postgresql import UUID
+
+
+def hash_password(password: str) -> bytes:
+    """Hashes the user password for security"""
+    salt = bcrypt.gensalt()
+
+    hash_pw = bcrypt.hashpw(password.encode(), salt)
+    return hash_pw
+
+
+class AuthUser(Base):
+    """User authentication data model.
+    
+    This model is used to store user authentication data.
+    eg. password, username, email for login purposes.
+    it's a one-to-one relationship with the User model.
+    
+    It has a CheckConstraint that ensures that either username or email is not null.
+    so if you used username to create the user, email can be null and vice versa.
+    but one of them must not be null.
+    """
+    __tablename__ = "auth_users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid7)
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), unique=True, nullable=False
+    )
+    username = Column(String(50), unique=True, nullable=True)
+    email = Column(String(100), unique=True, nullable=True)
+    password = Column(String(255), nullable=False)
+
+    user = relationship("User", uselist=False, back_populates="auth_user")
+    
+    # CheckConstraint ensures that either username or email is not null
+    __table_args__ = (CheckConstraint("NOT(username IS NULL AND email IS NULL)"),)
+
+    def __init__(self, **kwargs):
+        """Initializes a user instance"""
+        keys = ["username", "email", "password", "user_id"]
+        for key, value in kwargs.items():
+            if key in keys:
+                if key == "password":
+                    value = hash_password(value)
+                setattr(self, key, value)
+
+    def __str__(self):
+        return getattr(self, "username", self.email)

--- a/api/v1/models/oauth.py
+++ b/api/v1/models/oauth.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+""" OAuth User data model
+"""
+from sqlalchemy import (
+    Column,
+    String,
+    ForeignKey,
+)
+from sqlalchemy.orm import relationship
+from api.v1.models.base import Base
+from uuid_extensions import uuid7
+from sqlalchemy.dialects.postgresql import UUID
+
+
+class OAuthUser(Base):
+    """User OAuth data model.
+    
+    This model is the alternative to the AuthUser model.
+    That allows users to login with their social media accounts.
+    eg. Google, Facebook, Twitter, etc.
+    It has a one-to-one relationship with the User model.
+    """
+    __tablename__ = "oauth_users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid7)
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), unique=True, nullable=False
+    )
+    oauth_provider = Column(String(50), nullable=False)
+    oauth_id = Column(String(60), nullable=False)
+    email = Column(String(100), nullable=True)
+
+    user = relationship("User", back_populates="oauth_user")
+
+    def __init__(self, **kwargs):
+        """Initializes a user instance"""
+        keys = ["oauth_provider", "oauth_id", "user_id"]
+        for key, value in kwargs.items():
+            if key in keys:
+                setattr(self, key, value)
+
+    def __str__(self):
+        return getattr(self, "username", self.oauth_id)

--- a/api/v1/models/user.py
+++ b/api/v1/models/user.py
@@ -24,12 +24,15 @@ from sqlalchemy.dialects.postgresql import UUID
 
 
 class User(BaseModel, Base):
+    """User data model.
+    
+    This model is used to store user data.
+    eg. first_name, last_name, etc.
+    no critical data should be stored here. refer to AuthUser model for that.
+    """
     __tablename__ = 'users'
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid7)
-    username = Column(String(50), unique=True, nullable=False)
-    email = Column(String(100), unique=True, nullable=False)
-    password = Column(String(255), nullable=False)
     first_name = Column(String(50))
     last_name = Column(String(50))
     is_active = Column(Boolean, default=True)
@@ -37,6 +40,8 @@ class User(BaseModel, Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     profile = relationship("Profile", uselist=False, back_populates="user")
+    auth_user = relationship("AuthUser", uselist=False, back_populates="user")
+    oauth_user = relationship("OAuthUser", uselist=False, back_populates="user")
     organizations = relationship(
             "Organization",
             secondary=user_organization_association,
@@ -45,12 +50,11 @@ class User(BaseModel, Base):
 
     def to_dict(self):
         obj_dict = super().to_dict()
-        obj_dict.pop("password")
         return obj_dict
 
 
     def __str__(self):
-        return self.email
+        return f'{self.first_name} {self.last_name}'
 
 class WaitlistUser(BaseModel, Base):
     __tablename__ = 'waitlist_users'


### PR DESCRIPTION
Refactored the User model to only include public data and enable login to the app with username / email or using social authentication

#### Added AuthUser model

```sql
AuthUser:
  id
  user_id  // reference to related user
  email
  username
  password

-- there is a constraint to allow email / or username to be null and not both of them
-- the password is hashed before it get stored in the database
```

#### Added OAuthUser model

```sql
OAuthUser:
  id
  user_id  // reference to related user
  oauth_provider
  oauth_id
  email // optional

```

No endpoint have created in this pull request.

This model will allow others to start creating auth endpoints and enable route protection.

## Related Issues:

- Issue (https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/20)
- Issue (https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/29)
- Issue (https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/33)
- Issue (https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/55)
​

Motivation and Context

Database modification is taking a long time and this model is not taken into account and will cause problems later.
also it will allow other to start to work more faster



How Has This Been Tested?

All migration has been done successfully but there is a need for a test file _ the one this repo is outdated.
​



Types of changes

- [x] New feature: isolate users sensitive information like email password and username from the user model.

- [x] New feature: enable OAuth and passwordless login for new users.



Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.