### PR TITLE
bug: Fixed incorrect import for declarative_base instance

### DIFF
--- a/api/db/database.py
+++ b/api/db/database.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """ The database module
 """
-from sqlalchemy.ext.declarative import declarative_base
+from api.v1.models.base import Base
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import create_engine
 from api.utils.settings import settings, BASE_DIR
@@ -39,7 +39,6 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 db_session = scoped_session(SessionLocal)
 
-Base = declarative_base()
 
 def create_database():
     return Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
**Summary**:

This pull request fixes a bug caused by redeclaration of the declarative_base instance in the database.py file.

![Screenshot (427)](https://github.com/user-attachments/assets/abd94cb0-8540-4d8f-b5f7-c9abe86c176f)

The following changes were made:

1. Remove import line of declarative_base from database.py file
2. Import already declared instance of declarative_base from the models.base module
3. Use this imported Base instance to create the tables
