### PR TITLE
Refactor Alembic Model Imports and Create Base Router for FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ python3 seed.py
 
 After creating new tables, or adding new models. Make sure to run alembic revision --autogenerate -m "Migration messge"
 
+After creating new tables, or adding new models. Make sure you import the new model properly in th 'api/v1/models/__init__.py file
+
+After importing it in the init file, you need not import it in the /alembic/env.py file anymore
+
+
+**Adding new routes**
+
+To add a new route, confirm if a file relating to that route is not already created. If it is add the route in that file using the already declared router
+
+If the there is no file relating to the route in the 'api/v1/routes/' directory create a new one following the naming convention
+
+After creating the new route file, declare the router and add the prefix as well as the tag
+
+The prefix should not include the base prefix ('/api/v1') as it is already includedin the base `api_version_one` router
+
+After creating the router, import it in the 'api/v1/routes/__init__.py' file and include the router in the `api_version_one` router using
+```python
+api_version_one.include_router(<router_name>)
+```
+
 ## TEST THE ENDPOINT
 - run the following code
 ```

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,18 +3,8 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
 from decouple import config as decouple_config
-from api.v1.models.user import User, WaitlistUser
-from api.v1.models.org import Organization
-from api.v1.models.profile import Profile
-from api.v1.models.product import Product
+from api.v1.models import *
 from api.v1.models.base import Base
-from api.v1.models.subscription import Subscription
-from api.v1.models.blog import Blog
-from api.v1.models.job import Job
-from api.v1.models.invitation import Invitation
-from api.v1.models.role import Role
-from api.v1.models.permission import Permission
-from api.v1.models.newsletter import NEWSLETTER
 
 
 # this is the Alembic Config object, which provides

--- a/api/v1/models/__init__.py
+++ b/api/v1/models/__init__.py
@@ -1,0 +1,11 @@
+from api.v1.models.user import User, WaitlistUser
+from api.v1.models.org import Organization
+from api.v1.models.profile import Profile
+from api.v1.models.product import Product
+from api.v1.models.subscription import Subscription
+from api.v1.models.blog import Blog
+from api.v1.models.job import Job
+from api.v1.models.invitation import Invitation
+from api.v1.models.role import Role
+from api.v1.models.permission import Permission
+from api.v1.models.newsletter import NEWSLETTER

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from api.v1.routes.auth import auth
+from api.v1.routes.roles import role
+from api.v1.routes.newsletter_router import newsletter
+
+api_version_one = APIRouter(prefix="/api/v1")
+
+api_version_one.include_router(auth)
+api_version_one.include_router(role)
+api_version_one.include_router(newsletter)

--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -30,7 +30,7 @@ from api.v1.models.product import Product
 db = next(get_db())
 
 
-auth = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+auth = APIRouter(prefix="/auth", tags=["auth"])
 
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/api/v1/routes/newsletter_router.py
+++ b/api/v1/routes/newsletter_router.py
@@ -34,9 +34,9 @@ async def custom_exception_handler(request: Request, exc: CustomException):
         }
     )
 
-router = APIRouter()
+newsletter = APIRouter(prefix='/pages', tags=['Newsletter'])
 
-@router.post('/api/v1/pages/newsletter', tags=['Newsletter'])
+@newsletter.post('/newsletter')
 async def sub_newsletter(request: EMAILSCHEMA, db: Session = Depends(get_db)):
     """
     Newsletter subscription endpoint

--- a/api/v1/routes/roles.py
+++ b/api/v1/routes/roles.py
@@ -16,9 +16,9 @@ from api.v1.models.role import Role
 from api.v1.models.permission import Permission
 from api.utils.dependencies import get_current_admin
 
-role = APIRouter(prefix="/api/v1", tags=["Roles"])
+role = APIRouter(prefix="/roles", tags=["Roles"])
 
-@role.post("/roles", response_model=ResponseModel, status_code=status.HTTP_201_CREATED)
+@role.post("/", response_model=ResponseModel, status_code=status.HTTP_201_CREATED)
 def create_role(current_admin: Annotated[User, Depends(get_current_admin)], role: RoleCreate, db: Session = Depends(get_db)):
     db_role = db.query(Role).filter(Role.role_name == role.role_name).first()
     if db_role:

--- a/main.py
+++ b/main.py
@@ -6,14 +6,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from api.db.database import Base, engine
 
-from api.v1.routes.newsletter_router import router as newsletter
 from api.v1.routes.newsletter_router import (
     CustomException,
     custom_exception_handler
 )
 
-from api.v1.routes.auth import auth
-from api.v1.routes.roles import role
+from api.v1.routes import api_version_one
 
 Base.metadata.create_all(bind=engine)
 
@@ -37,9 +35,8 @@ app.add_middleware(
 )
 
 app.add_exception_handler(CustomException, custom_exception_handler) # Newsletter custom exception registration
-app.include_router(newsletter, tags=["Newsletter"])
 
-app.include_router(auth)
+app.include_router(api_version_one)
 
 
 


### PR DESCRIPTION
This pull request improves the way models are imported in the alembic/env.py file by using a wildcard import from the api.v1.models package. Additionally, it introduces a base router for the FastAPI app, with a prefix of /api/v1, which will consolidate all endpoint routers.

​

​

## Related Issue (https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/152)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
      ​
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
