### PR TITLE
[FEAT] - Implemented endpoint to create a Testimonial

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -4,6 +4,7 @@ from sqlalchemy import pool
 from alembic import context
 from decouple import config as decouple_config
 from api.v1.models import *
+from api.v1.models.testimonial import Testimonial
 from api.v1.models.base import Base
 
 

--- a/api/v1/models/testimonial.py
+++ b/api/v1/models/testimonial.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Testimonial data model
+map testimonial table into 
+a python object (Testimonial class)
+"""
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    ForeignKey,
+    func
+)
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from api.v1.models.base import Base
+from api.v1.models.base_model import BaseModel
+from sqlalchemy.dialects.postgresql import UUID
+
+class Testimonial(BaseModel, Base):
+    __tablename__ = 'testimonials'
+
+    firstname = Column(String(50), nullable=False)
+    lastname = Column(String(50), nullable=False)
+    content = Column(Text, nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'))
+
+    user = relationship("User", backref="testimonials")
+
+
+    def __str__(self):
+        return f"{self.firstname} {self.lastname}: {self.content}"

--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -14,6 +14,7 @@ from api.v1.models.job import Job
 from api.v1.models.invitation import Invitation
 from api.v1.models.role import Role
 from api.v1.models.permission import Permission
+from api.v1.models.testimonial import Testimonial
 from datetime import datetime, timedelta
 from api.v1.schemas.token import Token, LoginRequest
 from api.v1.schemas.auth import UserBase, SuccessResponse, SuccessResponseData, UserCreate

--- a/api/v1/routes/exception_handler.py
+++ b/api/v1/routes/exception_handler.py
@@ -5,7 +5,6 @@ Handles 400, 401 and 500 HTTP errors
 
 from fastapi import Request, HTTPException, status
 from fastapi.responses import JSONResponse
-from api.utils.json_response import JsonResponseDict
 from pydantic import BaseModel
 from typing import Type
 from fastapi.exceptions import RequestValidationError

--- a/api/v1/routes/exception_handler.py
+++ b/api/v1/routes/exception_handler.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Handles 400, 401 and 500 HTTP errors
+"""
+
+from fastapi import Request, HTTPException, status
+from fastapi.responses import JSONResponse
+from api.utils.json_response import JsonResponseDict
+from pydantic import BaseModel
+from typing import Type
+from fastapi.exceptions import RequestValidationError
+
+
+class ErrorResponse(BaseModel):
+    status: str
+    message: str
+    status_code: int
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "status": "Unauthorized" if exc.status_code == 401 else "Internal Server Error",
+            "message": "Unauthorized. Please log in." if exc.status_code == 401 else "Internal Server Error. Please try again later.",
+            "status_code": exc.status_code
+        }
+    )
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    return JSONResponse(
+        status_code=400,
+        content={
+            "status": "Bad Request",
+            "message": "Please check the submitted data",
+            "status_code": 400
+        }
+    )
+
+async def internal_server_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content={
+            "status": "Internal Server Error",
+            "message": "Internal Server Error. Please try again later.",
+            "status_code": 500
+        }
+    )

--- a/api/v1/routes/testimonial.py
+++ b/api/v1/routes/testimonial.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Testimonial route to create a testimonial
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from sqlalchemy.orm import Session
+from fastapi.responses import JSONResponse
+from api.v1.schemas.testimonial import TestimonialCreate, TestimonialResponse, SuccessResponse
+from api.db.database import get_db
+from api.v1.models.testimonial import Testimonial
+from api.utils.dependencies import get_current_user
+
+router = APIRouter(prefix="/api/v1", tags=["testimonials"])
+
+@router.post("/testimonials", response_model=SuccessResponse)
+def create_testimonial(testimonial: TestimonialCreate, db: Session = Depends(get_db), current_user: dict = Depends(get_current_user)):
+    db_testimonial = Testimonial( 
+    	firstname=testimonial.firstname,
+        lastname=testimonial.lastname,
+        content=testimonial.content,
+        user_id=current_user.id
+    )
+    db.add(db_testimonial)
+    db.commit()
+    db.refresh(db_testimonial)
+
+    response_data = TestimonialResponse(
+        id=db_testimonial.id,
+        firstname=db_testimonial.firstname,
+        lastname=db_testimonial.lastname,
+        content=db_testimonial.content,
+        created_at=db_testimonial.created_at,
+        updated_at=db_testimonial.updated_at
+    )
+
+    return SuccessResponse(
+        status="success",
+        message="Testimonial created successfully",
+        data=response_data
+    )

--- a/api/v1/schemas/testimonial.py
+++ b/api/v1/schemas/testimonial.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from uuid import UUID
+from datetime import datetime
+
+class TestimonialCreate(BaseModel):
+    firstname: str
+    lastname: str
+    content: str
+
+class TestimonialResponse(BaseModel):
+    id: UUID
+    firstname: str
+    lastname: str
+    content: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class SuccessResponse(BaseModel):
+    status: str
+    message: str
+    data: TestimonialResponse

--- a/main.py
+++ b/main.py
@@ -11,6 +11,13 @@ from api.v1.routes.newsletter_router import (
     custom_exception_handler
 )
 
+from api.v1.routes.testimonial import router as testimonial_router
+from api.v1.routes.exception_handler import (
+        http_exception_handler,
+        validation_exception_handler,
+        internal_server_error_handler
+        )
+
 from api.v1.routes import api_version_one
 
 Base.metadata.create_all(bind=engine)
@@ -20,6 +27,7 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
+app.include_router(testimonial_router)
 
 origins = [
     "http://localhost:3000",

--- a/tests/v1/test_create_testimonial.py
+++ b/tests/v1/test_create_testimonial.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Pytest
+Test case for creating a Testimonial
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+
+from main import app
+from api.utils.auth import hash_password
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_db():
+    """
+    Create a mock database session
+    """
+    mock_session = MagicMock()
+    yield mock_session
+
+def test_create_testimonial_success(mock_db, mocker):
+    """
+    Mock get_current_user
+    """
+    mock_user = {"id": 1, "username": "testuser"}
+    mocker.patch("api.utils.dependencies.get_current_user", return_value=mock_user)
+
+
+    mock_db.add = MagicMock()
+    mock_db.commit = MagicMock()
+    mock_db.refresh = MagicMock()
+
+    mock_testimonial = MagicMock()
+    mock_testimonial.id = 1
+    mock_testimonial.firstname = "John"
+    mock_testimonial.lastname = "Doe"
+    mock_testimonial.content = "This is a great service!"
+    mock_testimonial.created_at = "2024-07-21T00:00:00Z"
+    mock_testimonial.updated_at = "2024-07-21T00:00:00Z"
+
+    mocker.patch("api.v1.models.testimonial.Testimonial", return_value=mock_testimonial)
+
+    login_data = {"username": "testuser", "password": "testpassword"}
+    response = client.post("/api/v1/auth/login", json=login_data)
+    access_token = response.json().get("access_token")
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    testimonial_data = {
+        "firstname": "John",
+        "lastname": "Doe",
+        "content": "This is a great service!"
+    }
+
+    response = client.post("/api/v1/testimonials", json=testimonial_data, headers=headers)
+    assert response.status_code == 201
+    assert response.json()["status"] == "success"
+    assert response.json()["message"] == "Testimonial created successfully"
+    assert response.json()["data"]["firstname"] == "John"
+    assert response.json()["data"]["lastname"] == "Doe"
+    assert response.json()["data"]["content"] == "This is a great service!"
+
+def test_create_testimonial_unauthenticated():
+    testimonial_data = {
+        "firstname": "Jane",
+        "lastname": "Doe",
+        "content": "Amazing experience!"
+    }
+
+    response = client.post("/api/v1/testimonials", json=testimonial_data)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+


### PR DESCRIPTION
# Added a protected endpoint to create testimonials

## Description

This PR adds a new endpoint to create testimonials. The endpoint is protected and requires user authentication. It uses the user's ID to associate the testimonial with the user. The endpoint accepts the first name, last name, and content of the testimonial.

## Related Issue (Link to issue ticket)

[[Link to issue ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/79)]

## Motivation and Context

This change is required to allow authenticated users to submit testimonials. This feature enhances user engagement and provides valuable feedback that can be displayed on the platform.

## How Has This Been Tested?

- The endpoint was tested using curl, FastAPI Swagger and Postman.
- Verified that only authenticated users can access the endpoint.
- Tested the endpoint with valid and invalid data to ensure proper validation and error handling.
- Ensured that the testimonial is correctly saved in the database and is associated with the authenticated user.

## Screenshots (if appropriate - Postman, etc):

![Curl Request](https://github.com/ugberaeseac/hng_boilerplate_python_fastapi_web/blob/ugberaeseac/tests/v1/test.png)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
