### PR TITLE
Added recovery email function

### DIFF
--- a/api/v1/models/user.py
+++ b/api/v1/models/user.py
@@ -34,6 +34,9 @@ class User(BaseModel, Base):
     is_active = Column(Boolean, server_default=text('true'))
     is_admin = Column(Boolean, server_default=text('false'))
 
+    recovery_email = Column(String(100), nullable=True)
+
+
     profile = relationship("Profile", uselist=False, back_populates="user", cascade="all, delete-orphan")
     organizations = relationship("Organization", secondary=user_organization_association, back_populates="users")
     roles = relationship('Role', secondary=user_role_association, back_populates='users')

--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr, validator
 
 
 class DeactivateUserSchema(BaseModel):
@@ -7,4 +7,16 @@ class DeactivateUserSchema(BaseModel):
 
     reason: Optional[str] = None
     confirmation: bool
+
+class RecoveryEmail(BaseModel):
+    email: EmailStr
+
+    @validator("email")
+    def validate_email(cls, value):
+        if not value:
+            raise ValueError("Email is required")
+        return value
     
+class SuccessResponse(BaseModel):
+    status_code: int = Field(200, example=200)
+    message: str


### PR DESCRIPTION
Added Reocvery Email dunction

​

## Description

<!--- Describe your changes in detail -->
I added the endpoint to enable users to add a recovery email.
​

## Related Issue (Link to issue ticket)
https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/59

​

## Motivation and Context

It enables users to be able to have a backup email in case they get locked out of their account


​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
