### PR TITLE
added the endpoint for user account deletion

### DIFF
--- a/api/v1/routes/user.py
+++ b/api/v1/routes/user.py
@@ -60,3 +60,19 @@ async def reactivate_account(request: Request, db: Session = Depends(get_db)):
         status_code=200,
         message='User reactivation successful',
     )
+
+
+@user.patch("/current-user/", status_code=status.HTTP_204_NO_CONTENT)
+def delete_current_user(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user)
+):
+    if not current_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    # Perform the deletion logic here. For a soft delete, you might just set is_active to False
+    db.delete(current_user)
+    db.commit()
+
+    return None

--- a/tests/v1/user_delete_test.py
+++ b/tests/v1/user_delete_test.py
@@ -1,0 +1,81 @@
+import sys
+import os
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from datetime import datetime, timezone
+from fastapi import status
+from api.db.database import get_db
+from uuid_extensions import uuid7
+from api.v1.services.user import user_service
+from api.v1.models.user import User
+from main import app
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+import pytest
+
+client = TestClient(app)
+DELETE_USER_ENDPOINT = '/api/v1/users/current-user/'
+
+
+@pytest.fixture
+def mock_db_session():
+    """Fixture to create a mock database session."""
+
+    with patch("api.v1.services.user.get_db", autospec=True) as mock_get_db:
+        mock_db = MagicMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        yield mock_db
+    app.dependency_overrides = {}
+
+
+@pytest.fixture
+def mock_user_service():
+    """Fixture to create a mock user service."""
+
+    with patch("api.v1.services.user.user_service", autospec=True) as mock_service:
+        yield mock_service
+
+
+def create_mock_user(mock_user_service, mock_db_session):
+    """Create a mock user in the mock database session."""
+    mock_user = User(
+        id=str(uuid7()),
+        username="testuser",
+        email="testuser@gmail.com",
+        password=user_service.hash_password("Testpassword@123"),
+        first_name='Test',
+        last_name='User',
+        is_active=True,
+        is_admin=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    mock_db_session.query.return_value.filter.return_value.first.return_value = mock_user
+    return mock_user
+
+
+@pytest.mark.usefixtures("mock_db_session", "mock_user_service")
+def test_successful_user_deletion(mock_user_service, mock_db_session):
+    """Test for successful user deletion."""
+    create_mock_user(mock_user_service, mock_db_session)
+
+    login_response = client.post("/api/v1/auth/login", data={
+        "username": "testuser",
+        "password": "Testpassword@123"
+    })
+    assert login_response.status_code == status.HTTP_200_OK
+    access_token = login_response.json()['data']['access_token']
+
+    delete_response = client.patch(DELETE_USER_ENDPOINT, headers={
+                                   'Authorization': f'Bearer {access_token}'})
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.usefixtures("mock_db_session", "mock_user_service")
+def test_unauthorized_user_deletion(mock_user_service, mock_db_session):
+    """Test for unauthorized user deletion."""
+    delete_response = client.patch(DELETE_USER_ENDPOINT)
+    assert delete_response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Description

I created the `/api/v1/users/current-user/` endpoint which allows users to delete their account. I also wrote tests for it which are in the `user_delete_test.py`.

## Related Issue (Link to issue ticket)

<!--- Please link to the issue here: -->
This change does not link to an existing issue but adds new functionality.

## Motivation and Context

This change is required to give users the ability to delete their accounts from the system. This feature improves user autonomy and helps maintain compliance with data privacy regulations.

## How Has This Been Tested?

I tested my changes by writing and running unit tests using `pytest`. The tests are located in `user_delete_test.py` and cover scenarios including successful account deletion and unauthorized access attempts.

<!--- Include screenshots of the Postman tests, if available -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.