### PR TITLE
Feat: added mark notification as read endpoint

### DIFF
--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter
 from api.v1.routes.auth import auth
 from api.v1.routes.newsletter import newsletter
 from api.v1.routes.user import user
+from api.v1.routes.notification import notification
 
 api_version_one = APIRouter(prefix="/api/v1")
 
 api_version_one.include_router(auth)
 api_version_one.include_router(newsletter)
 api_version_one.include_router(user)
+api_version_one.include_router(notification)

--- a/api/v1/routes/notification.py
+++ b/api/v1/routes/notification.py
@@ -1,0 +1,29 @@
+from fastapi import Depends, status, APIRouter, Path
+from sqlalchemy.orm import Session
+from api.utils.success_response import success_response
+from api.v1.models import User
+from typing import Annotated
+from api.db.database import get_db
+from api.v1.services.user import user_service
+from api.v1.services.notification import notification_service
+
+notification = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+@notification.patch(
+    "/{id}",
+    summary="Mark a notification as read",
+    description="This endpoint marks a notification as `read`. User must be authenticated an must be the owner of a notification to mark it as `read`",
+    status_code=status.HTTP_200_OK,
+    response_model=success_response
+)
+def mark_notification_as_read(
+    id: Annotated[str, Path()],
+    current_user: User = Depends(user_service.get_current_user),
+    db: Session = Depends(get_db),
+):
+    notification_service.mark_notification_as_read(
+        notification_id=id, user=current_user, db=db
+    )
+
+    return success_response(status_code=200, message="Notifcation marked as read")

--- a/api/v1/services/notification.py
+++ b/api/v1/services/notification.py
@@ -1,0 +1,55 @@
+from fastapi import Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from api.core.base.services import Service
+from api.db.database import get_db
+from api.v1.models.notifications import Notification
+from api.v1.models.user import User
+
+
+class NotificationService(Service):
+    def mark_notification_as_read(
+        self,
+        notification_id: str,
+        user: User,
+        db: Session = Depends(get_db),
+    ):
+        notification = (
+            db.query(Notification)
+            .filter(Notification.id == notification_id, Notification.user_id == user.id)
+            .first()
+        )
+
+        if not notification:
+            raise HTTPException(status_code=404, detail="Notification not found")
+
+        # check if the notification is marked as read
+
+        if notification.status == "read":
+            return
+
+        # update notification status
+
+        notification.status = "read"
+
+        # commit changes
+
+        db.commit()
+
+    def create(self):
+        super().create()
+
+    def delete(self):
+        super().delete()
+
+    def fetch(self, db: Session):
+        super().fetch()
+
+    def fetch_all(self):
+        super().fetch_all()
+
+    def update(self):
+        super().update()
+
+
+notification_service = NotificationService()

--- a/tests/v1/test_notification.py
+++ b/tests/v1/test_notification.py
@@ -1,0 +1,129 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from decouple import config
+from main import app
+from api.db.database import get_db
+from api.v1.models.user import User
+from api.v1.models.base import Base
+from api.v1.services.user import user_service
+from api.v1.models.notifications import Notification
+
+SQLALCHEMY_DATABASE_URL = config("DB_URL")
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def test_db():
+    db = TestingSessionLocal()
+    yield db
+    db.close()
+
+
+def test_mark_notification_as_read(test_db):
+    # Create test user
+
+    user = User(
+        username="testuser1",
+        email="testuser1@gmail.com",
+        password=user_service.hash_password("Testpassword@123"),
+        first_name="Test",
+        last_name="User",
+        is_active=False,
+    )
+    test_db.add(user)
+    test_db.commit()
+    test_db.refresh(user)
+
+    # Create test notification
+
+    notification = Notification(
+        user_id=user.id,
+        title="Test notification",
+        message="This is my test notification message",
+    )
+    test_db.add(notification)
+    test_db.commit()
+    test_db.refresh(notification)
+
+    # get access token
+
+    login = client.post(
+        "api/v1/auth/login",
+        data={"username": "testuser1", "password": "Testpassword@123"},
+    )
+
+    access_token = login.json()["data"]["access_token"]
+    headers = {"authorization": f"Bearer {access_token}"}
+
+    response = client.patch(f"/api/v1/notifications/{notification.id}", headers=headers)
+
+    # clean up the database
+
+    test_db.query(Notification).delete()
+    test_db.query(User).delete()
+    test_db.commit()
+    test_db.close()
+
+    assert response.status_code == 200
+    assert response.json()["success"] == True
+    assert response.json()["status_code"] == 200
+    assert response.json()["message"] == "Notifcation marked as read"
+
+
+def test_mark_notification_as_read_unauthenticated_user(test_db):
+    # Create test user
+
+    user = User(
+        username="testuser1",
+        email="testuser1@gmail.com",
+        password=user_service.hash_password("Testpassword@123"),
+        first_name="Test",
+        last_name="User",
+        is_active=False,
+    )
+    test_db.add(user)
+    test_db.commit()
+    test_db.refresh(user)
+
+    # Create test notification
+
+    notification = Notification(
+        user_id=user.id,
+        title="Test notification",
+        message="This is my test notification message",
+    )
+    test_db.add(notification)
+    test_db.commit()
+    test_db.refresh(notification)
+
+    response = client.patch(f"/api/v1/notifications/{notification.id}")
+
+    # clean up the database
+
+    test_db.query(Notification).delete()
+    test_db.query(User).delete()
+    test_db.commit()
+    test_db.close()
+
+    assert response.status_code == 401
+    assert response.json()["success"] == False
+    assert response.json()["status_code"] == 401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description

<!--- Describe your changes in detail -->
This endpoint adds a new endpoint `[PATCH] /api/v1/notifications/{id}` which marks a notification as read. The notification can only be marked as `read` if the user making the request is the owner of the notification with the given `id`.

​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[Related issue](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/336)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate - Postman, etc):
<img width="677" alt="Screenshot 2024-07-24 142810" src="https://github.com/user-attachments/assets/4f97efee-a662-4b42-aa0c-f18cf7a2f9ac">
<img width="960" alt="image" src="https://github.com/user-attachments/assets/24175414-f045-4952-af0f-72e293d347d1">


​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
