### PR TITLE
feat: create route for deleting blog post

### DIFF
--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -22,11 +22,11 @@ def get_all_blogs(db: Session = Depends(get_db)):
 @blog.delete("/api/v1/blogs/{id}", response_model=DeleteBlogResponse, status_code=status.HTTP_200_OK)
 def delete_blog(id: str, db: Session = Depends(get_db), current_user: User = Depends(get_super_admin)):
     if not current_user:
-        return {"status_code":401, "message":"Unauthorized User"}
+        return {"status_code":403, "message":"Unauthorized User"}
     post = db.query(Blog).filter(Blog.id == id, Blog.is_deleted == False).first()
     
     if not post:
-        return {"status_code":status.HTTP_404_NOT_FOUND, "detail": "Blog with the given ID does not exist"}
+        return {"status_code":status.HTTP_404_NOT_FOUND, "message": "Blog with the given ID does not exist"}
     
     post.is_deleted = True
     # db.delete(post)

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -5,9 +5,9 @@ from sqlalchemy.orm import Session
 
 from api.db.database import get_db
 from api.utils.dependencies import get_super_admin
+from api.v1.models import User
 from api.v1.models.blog import Blog
 from api.v1.schemas.blog import BlogResponse, DeleteBlogResponse
-from api.v1.schemas.user import User
 
 blog = APIRouter(prefix="/blogs", tags=["Blog"])
 

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -29,7 +29,7 @@ def delete_blog(id: str, db: Session = Depends(get_db), current_user: User = Dep
         return {"status_code":status.HTTP_404_NOT_FOUND, "detail": "Blog with the given ID does not exist"}
     
     post.is_deleted = True
-    db.delete(post)
+    # db.delete(post)
     db.commit()
     
     return {"message": "Blog post deleted successfully", "status_code": 200}

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -2,9 +2,9 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from utils.dependencies import get_super_admin
 
 from api.db.database import get_db
+from api.utils.dependencies import get_super_admin
 from api.v1.models.blog import Blog
 from api.v1.schemas.blog import BlogResponse, DeleteBlogResponse
 from api.v1.schemas.user import User

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
 from typing import List
 
-from api.v1.models.blog import Blog
-from api.v1.schemas.blog import BlogResponse
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from utils.dependencies import get_super_admin
+
 from api.db.database import get_db
+from api.v1.models.blog import Blog
+from api.v1.schemas.blog import BlogResponse, DeleteBlogResponse
+from api.v1.schemas.user import User
 
 blog = APIRouter(prefix="/blogs", tags=["Blog"])
 
@@ -15,3 +18,18 @@ def get_all_blogs(db: Session = Depends(get_db)):
         return []
     return blogs
 
+
+@blog.delete("/api/v1/blogs/{id}", response_model=DeleteBlogResponse, status_code=status.HTTP_200_OK)
+def delete_blog(id: str, db: Session = Depends(get_db), current_user: User = Depends(get_super_admin)):
+    if not current_user:
+        return {"status_code":401, "message":"Unauthorized User"}
+    post = db.query(Blog).filter(Blog.id == id, Blog.is_deleted == False).first()
+    
+    if not post:
+        return {"status_code":status.HTTP_404_NOT_FOUND, "detail": "Blog with the given ID does not exist"}
+    
+    post.is_deleted = True
+    db.delete(post)
+    db.commit()
+    
+    return {"message": "Blog post deleted successfully", "status_code": 200}

--- a/api/v1/schemas/blog.py
+++ b/api/v1/schemas/blog.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
-from datetime import datetime
+
+from pydantic import BaseModel
+
 
 class BlogResponse(BaseModel):
     id: UUID
@@ -18,3 +20,7 @@ class BlogResponse(BaseModel):
     class Config:
         orm_mode = True
 
+
+class DeleteBlogResponse(BaseModel):
+    message: str
+    status_code: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Pygments==2.18.0
 PyJWT==2.8.0
 PyMySQL==1.1.1
 pytest==8.2.2
-pytest-asyncio==0.23.8
+pytest-asyncio==0.2c3.8
 python-decouple==3.8
 python-dotenv==1.0.1
 python-jose==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Pygments==2.18.0
 PyJWT==2.8.0
 PyMySQL==1.1.1
 pytest==8.2.2
-pytest-asyncio==0.2c3.8
+pytest-asyncio==0.23.8
 python-decouple==3.8
 python-dotenv==1.0.1
 python-jose==3.3.0

--- a/tests/v1/delete_blog_test.py
+++ b/tests/v1/delete_blog_test.py
@@ -28,7 +28,7 @@ def test_delete_blog_success():
     blog_id = "test_id"
     mock_blog = Blog(id=blog_id, title="Test Blog", content="Test Content", is_deleted=False)
     
-    with patch('api.v1.models.blog.Blog.query') as mock_query:
+    with patch('api.v1.models.blog.Blog') as mock_query:
         mock_query.filter.return_value.first.return_value = mock_blog
         
         response = client.delete(f"/api/v1/blog/{blog_id}")
@@ -49,7 +49,7 @@ def test_delete_blog_unauthorized():
 def test_delete_blog_not_found():
     blog_id = "non_existent_id"
     
-    with patch('api.v1.models.blog.Blog.query') as mock_query:
+    with patch('api.v1.models.blog.Blog') as mock_query:
         mock_query.filter.return_value.first.return_value = None
         
         response = client.delete(f"/api/v1/blog/{blog_id}")
@@ -63,7 +63,7 @@ def test_get_all_blogs():
         Blog(id="2", title="Blog 2", content="Content 2", is_deleted=False)
     ]
     
-    with patch('api.v1.models.blog.Blog.query') as mock_query:
+    with patch('api.v1.models.blog.Blog') as mock_query:
         mock_query.filter.return_value.all.return_value = mock_blogs
         
         response = client.get("/blog/")

--- a/tests/v1/delete_blog_test.py
+++ b/tests/v1/delete_blog_test.py
@@ -25,7 +25,7 @@ app.dependency_overrides[get_super_admin] = mock_get_super_admin
 client = TestClient(app)
 
 def test_delete_blog_success():
-    blog_id = "test_id"
+    blog_id = "1"
     mock_blog = Blog(id=blog_id, title="Test Blog", content="Test Content", is_deleted=False)
     
     with patch('api.v1.models.blog.Blog') as mock_query:
@@ -34,17 +34,18 @@ def test_delete_blog_success():
         response = client.delete(f"/api/v1/blog/{blog_id}")
         
         assert response.status_code == 200
-        assert response.json() == {"message": "Blog post deleted successfully", "status_code": 202}
+        assert response.json() == {"message": "Blog post deleted successfully", "status_code": 200}
         assert mock_blog.is_deleted == True
 
 def test_delete_blog_unauthorized():
-    blog_id = "test_id"
+    blog_id = "1"
+    mock_blog = Blog(id=blog_id, title="Test Blog", content="Test Content", is_deleted=False)
     app.dependency_overrides[get_super_admin] = lambda: None
     
     response = client.delete(f"/api/v1/blog/{blog_id}")
     
-    assert response.status_code == 401
-    assert response.json()["detail"] == "Unauthorized User"
+    assert response.status_code == 403
+    assert response.json()["message"] == "Unauthorized User"
 
 def test_delete_blog_not_found():
     blog_id = "non_existent_id"
@@ -55,23 +56,7 @@ def test_delete_blog_not_found():
         response = client.delete(f"/api/v1/blog/{blog_id}")
         
         assert response.status_code == 404
-        assert response.json()["detail"] == "Blog with the given ID does not exist"
-
-def test_get_all_blogs():
-    mock_blogs = [
-        Blog(id="1", title="Blog 1", content="Content 1", is_deleted=False),
-        Blog(id="2", title="Blog 2", content="Content 2", is_deleted=False)
-    ]
-    
-    with patch('api.v1.models.blog.Blog') as mock_query:
-        mock_query.filter.return_value.all.return_value = mock_blogs
-        
-        response = client.get("/blog/")
-        
-        assert response.status_code == 200
-        assert len(response.json()) == 2
-        assert response.json()[0]["title"] == "Blog 1"
-        assert response.json()[1]["title"] == "Blog 2"
+        assert response.json()["message"] == "Blog with the given ID does not exist"
 
 
 if __name__ == "__main__":

--- a/tests/v1/delete_blog_test.py
+++ b/tests/v1/delete_blog_test.py
@@ -1,23 +1,22 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
 
 from api.db.database import get_db
 from api.utils.dependencies import get_super_admin
+from api.v1.models import User
 from api.v1.models.blog import Blog
-from api.v1.schemas.user import User
-from main import app  # assuming your FastAPI app is in main.py
+from main import app
 
 
-# Mock dependencies
+@pytest.fixture
 def mock_get_db():
-    # This should return a mock database session
-    return Session()
+    db_session = MagicMock()
+    yield db_session
 
+@pytest.fixture
 def mock_get_super_admin():
-    # This should return a mock super admin user
     return User(id="1", is_superadmin=True)
 
 app.dependency_overrides[get_db] = mock_get_db
@@ -26,17 +25,14 @@ app.dependency_overrides[get_super_admin] = mock_get_super_admin
 client = TestClient(app)
 
 def test_delete_blog_success():
-    # Arrange
     blog_id = "test_id"
     mock_blog = Blog(id=blog_id, title="Test Blog", content="Test Content", is_deleted=False)
     
     with patch('api.v1.models.blog.Blog.query') as mock_query:
         mock_query.filter.return_value.first.return_value = mock_blog
         
-        # Act
         response = client.delete(f"/api/v1/blog/{blog_id}")
         
-        # Assert
         assert response.status_code == 200
         assert response.json() == {"message": "Blog post deleted successfully", "status_code": 202}
         assert mock_blog.is_deleted == True
@@ -51,21 +47,17 @@ def test_delete_blog_unauthorized():
     assert response.json()["detail"] == "Unauthorized User"
 
 def test_delete_blog_not_found():
-    # Arrange
     blog_id = "non_existent_id"
     
     with patch('api.v1.models.blog.Blog.query') as mock_query:
         mock_query.filter.return_value.first.return_value = None
         
-        # Act
         response = client.delete(f"/api/v1/blog/{blog_id}")
         
-        # Assert
         assert response.status_code == 404
         assert response.json()["detail"] == "Blog with the given ID does not exist"
 
 def test_get_all_blogs():
-    # Arrange
     mock_blogs = [
         Blog(id="1", title="Blog 1", content="Content 1", is_deleted=False),
         Blog(id="2", title="Blog 2", content="Content 2", is_deleted=False)
@@ -74,11 +66,13 @@ def test_get_all_blogs():
     with patch('api.v1.models.blog.Blog.query') as mock_query:
         mock_query.filter.return_value.all.return_value = mock_blogs
         
-        # Act
         response = client.get("/blog/")
         
-        # Assert
         assert response.status_code == 200
         assert len(response.json()) == 2
         assert response.json()[0]["title"] == "Blog 1"
         assert response.json()[1]["title"] == "Blog 2"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/v1/delete_blog_test.py
+++ b/tests/v1/delete_blog_test.py
@@ -1,0 +1,84 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.db.database import get_db
+from api.utils.dependencies import get_super_admin
+from api.v1.models.blog import Blog
+from api.v1.schemas.user import User
+from main import app  # assuming your FastAPI app is in main.py
+
+
+# Mock dependencies
+def mock_get_db():
+    # This should return a mock database session
+    return Session()
+
+def mock_get_super_admin():
+    # This should return a mock super admin user
+    return User(id="1", is_superadmin=True)
+
+app.dependency_overrides[get_db] = mock_get_db
+app.dependency_overrides[get_super_admin] = mock_get_super_admin
+
+client = TestClient(app)
+
+def test_delete_blog_success():
+    # Arrange
+    blog_id = "test_id"
+    mock_blog = Blog(id=blog_id, title="Test Blog", content="Test Content", is_deleted=False)
+    
+    with patch('api.v1.models.blog.Blog.query') as mock_query:
+        mock_query.filter.return_value.first.return_value = mock_blog
+        
+        # Act
+        response = client.delete(f"/api/v1/blog/{blog_id}")
+        
+        # Assert
+        assert response.status_code == 200
+        assert response.json() == {"message": "Blog post deleted successfully", "status_code": 202}
+        assert mock_blog.is_deleted == True
+
+def test_delete_blog_unauthorized():
+    blog_id = "test_id"
+    app.dependency_overrides[get_super_admin] = lambda: None
+    
+    response = client.delete(f"/api/v1/blog/{blog_id}")
+    
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthorized User"
+
+def test_delete_blog_not_found():
+    # Arrange
+    blog_id = "non_existent_id"
+    
+    with patch('api.v1.models.blog.Blog.query') as mock_query:
+        mock_query.filter.return_value.first.return_value = None
+        
+        # Act
+        response = client.delete(f"/api/v1/blog/{blog_id}")
+        
+        # Assert
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Blog with the given ID does not exist"
+
+def test_get_all_blogs():
+    # Arrange
+    mock_blogs = [
+        Blog(id="1", title="Blog 1", content="Content 1", is_deleted=False),
+        Blog(id="2", title="Blog 2", content="Content 2", is_deleted=False)
+    ]
+    
+    with patch('api.v1.models.blog.Blog.query') as mock_query:
+        mock_query.filter.return_value.all.return_value = mock_blogs
+        
+        # Act
+        response = client.get("/blog/")
+        
+        # Assert
+        assert response.status_code == 200
+        assert len(response.json()) == 2
+        assert response.json()[0]["title"] == "Blog 1"
+        assert response.json()[1]["title"] == "Blog 2"


### PR DESCRIPTION
# Pull Request: Implement Blog Post Deletion API

## Related Issue
Closes #368

## Description
This pull request implements a new API endpoint for deleting blog posts. The endpoint is accessible only to super admin users and performs a soft delete on the specified blog post.

## Changes
- Added a new DELETE endpoint `/api/v1/blog/{id}`
- Implemented authorization check for super admin users
- Added soft delete functionality for blog posts
- Added comprehensive test coverage for the new endpoint

## Code Changes

### File: `api/v1/routes/blog.py`

```python
from utils.dependencies import get_super_admin
from api.v1.schemas.blog import  DeleteBlogResponse

blog = APIRouter(prefix="/blogs", tags=["Blog"])


@blog.delete("/api/v1/blogs/{id}", response_model=DeleteBlogResponse, status_code=status.HTTP_200_OK)
def delete_blog(id: str, db: Session = Depends(get_db), current_user: User = Depends(get_super_admin)):
    if not current_user:
        return {"status_code":403, "message":"Unauthorized User"}
    post = db.query(Blog).filter(Blog.id == id, Blog.is_deleted == False).first()
    
    if not post:
        return {"status_code":status.HTTP_404_NOT_FOUND, "message": "Blog with the given ID does not exist"}
    
    post.is_deleted = True
    # db.delete(post)
    db.commit()
    
    return {"message": "Blog post deleted successfully", "status_code": 200}