### PR TITLE
Add Endpoint for Job Listings

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from api.v1 import jobs
+
+router = APIRouter()
+router.include_router(jobs.router, prefix="/jobs", tags=["jobs"])

--- a/api/v1/crud/job.py
+++ b/api/v1/crud/job.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Session
+from models import Job
+from schemas.job import JobCreate
+
+def create_job(db: Session, job: JobCreate):
+    db_job = Job(**job.dict())
+    db.add(db_job)
+    db.commit()
+    db.refresh(db_job)
+    return db_job

--- a/api/v1/jobs.py
+++ b/api/v1/jobs.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from schemas.job import JobCreate, Job
+from crud.job import create_job
+from dependencies import get_db, get_current_admin_user
+
+router = APIRouter()
+
+@router.post("/create", response_model=Job)
+def create_job_route(
+    job: JobCreate, 
+    db: Session = Depends(get_db), 
+    current_user: str = Depends(get_current_admin_user)
+):
+    if not current_user:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return create_job(db=db, job=job)

--- a/api/v1/models/models.py
+++ b/api/v1/models/models.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, Float, Boolean
+from database import Base
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    description = Column(String)
+    company = Column(String)
+    location = Column(String)
+    salary = Column(Float, nullable=True)
+    is_active = Column(Boolean, default=True)

--- a/api/v1/schemas/job.py
+++ b/api/v1/schemas/job.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class JobCreate(BaseModel):
+    title: str
+    description: str
+    company: str
+    location: str
+    salary: Optional[float] = None
+    is_active: Optional[bool] = True
+
+class Job(JobCreate):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/tests/v1/test_jobs.py
+++ b/tests/v1/test_jobs.py
@@ -1,0 +1,50 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def admin_token():
+    # Replace this with actual logic to obtain a valid admin token
+    return "your_admin_token"
+
+def test_create_job(admin_token):
+    response = client.post(
+        "/api/v1/jobs/create",
+        json={
+            "title": "Software Engineer",
+            "description": "Develop software",
+            "company": "TechCorp",
+            "location": "Remote",
+            "salary": 70000,
+            "is_active": True
+        },
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "id" in data
+    assert data["title"] == "Software Engineer"
+    assert data["description"] == "Develop software"
+    assert data["company"] == "TechCorp"
+    assert data["location"] == "Remote"
+    assert data["salary"] == 70000
+    assert data["is_active"] == True
+
+def test_create_job_unauthorized():
+    response = client.post(
+        "/api/v1/jobs/create",
+        json={
+            "title": "Software Engineer",
+            "description": "Develop software",
+            "company": "TechCorp",
+            "location": "Remote",
+            "salary": 70000,
+            "is_active": True
+        }
+    )
+    
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Not authorized"}


### PR DESCRIPTION
### Summary
This pull request introduces a new endpoint `POST /api/v1/jobs/create` for creating job listings. This endpoint is restricted to admin users and includes functionality to add job details such as title, description, company, location, salary, and active status.

### Changes Made
- Added `POST /api/v1/jobs/create` endpoint to the `jobs` module in the `v1` API directory.
- Implemented route to handle job creation with data validation.
- Integrated the endpoint with the database to store job listings.
- Implemented access control to ensure only admin users can create jobs.

### Testing
- Added tests in `tests/test_jobs.py` to verify:
  - Successful job creation with valid admin token.
  - Unauthorized access without a valid admin token.

### Notes
- Ensure the admin token is set up correctly in your environment for testing.
- The endpoint requires proper authentication and authorization checks to function correctly.

Please review the changes and let me know if there are any adjustments needed.