### PR TITLE
FEAT: Added List Organization Products Endpoint 

### DIFF
--- a/api/utils/db_validators.py
+++ b/api/utils/db_validators.py
@@ -1,5 +1,7 @@
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
+from api.v1.models import User, Organization
+from api.utils.dependencies import get_current_user
 
 def check_model_existence(db: Session, model, id):
     '''Checks if a model exists by its id'''
@@ -11,3 +13,13 @@ def check_model_existence(db: Session, model, id):
         raise HTTPException(status_code=404, detail=f'{model.__name__} does not exist')
     
     return obj
+
+def check_user_in_org(user: User, organization: Organization):
+    '''Checks if a user is a member of an organization'''
+
+    if user not in organization.users:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are not a member of this organization"
+        )
+

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter
 from api.v1.routes.auth import auth
 from api.v1.routes.newsletter import newsletter
 from api.v1.routes.user import user
+from api.v1.routes.product import product
 
 api_version_one = APIRouter(prefix="/api/v1")
 
 api_version_one.include_router(auth)
 api_version_one.include_router(newsletter)
 api_version_one.include_router(user)
+api_version_one.include_router(product)

--- a/api/v1/routes/product.py
+++ b/api/v1/routes/product.py
@@ -1,0 +1,61 @@
+from fastapi import Depends, HTTPException, APIRouter, Request, Response, status, Query
+from sqlalchemy.orm import Session
+from typing import Annotated
+
+from api.utils.success_response import success_response
+from api.v1.models.product import Product
+from api.v1.schemas.user import DeactivateUserSchema, UserBase
+from api.db.database import get_db
+from api.v1.services.product import product_service
+from api.v1.schemas.product import ProductList
+from api.utils.dependencies import get_current_user
+from api.v1.services.user import user_service
+from api.v1.models import User
+
+product = APIRouter(prefix='/products', tags=['Products'])
+
+@product.get('/{org_id}', status_code=status.HTTP_200_OK, response_model=ProductList)
+def get_organization_products(
+    org_id: str,
+    current_user: Annotated[User, Depends(user_service.get_current_user)],
+    limit: Annotated[int, Query(ge=1, description="Number of products per page")] = 10,
+    page: Annotated[int, Query(ge=1, description="Page number (starts from 1)")] = 1,
+    db: Session = Depends(get_db), 
+    ):
+    '''
+    Endpoint to retrieve a paginated list of products of an organization.
+
+    Query parameter: 
+        - limit: Number of customer per page (default: 10, minimum: 1)
+        - page: Page number (starts from 1)
+    '''
+
+    products = product_service.fetch_by_organization(db, user=current_user, org_id=org_id, limit=limit, page=page)
+
+    total_products = len(products)
+
+    total_pages = int(total_products / limit) + (total_products % limit > 0)
+
+    product_data = [
+        {
+            "name": product.name,
+            "description": product.description,
+            "price": str(product.price)
+        }
+        for product in products
+    ]
+
+    data = {
+        "current_page": page,
+        "total_pages": total_pages,
+        "limit": limit,
+        "total_items": total_products,
+        "products": product_data
+    }
+
+    return success_response(
+        status_code=200, 
+        message="Successfully fetched organizations products", 
+        data=data
+        )
+

--- a/api/v1/schemas/product.py
+++ b/api/v1/schemas/product.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import List
+
+class ProductBase(BaseModel):
+    name: str
+    description: str
+    price: float
+
+class ProductList(BaseModel):
+    status_code: int
+    data: List[ProductBase]

--- a/api/v1/schemas/product.py
+++ b/api/v1/schemas/product.py
@@ -3,9 +3,19 @@ from typing import List
 
 class ProductBase(BaseModel):
     name: str
-    description: str
+    description: float
     price: float
 
+class ProductData(BaseModel):
+    current_page: int
+    total_pages: int
+    limit: int
+    total_items: int
+    products: List[ProductBase]
+
 class ProductList(BaseModel):
-    status_code: int
-    data: List[ProductBase]
+    status_code: int = 200
+    success: bool
+    message: str
+    data: ProductData
+    

--- a/seed.py
+++ b/seed.py
@@ -6,12 +6,6 @@ from api.v1.models.base import Base
 from api.v1.services.user import user_service
 from api.db.database import create_database, get_db
 
-
-
-
-
-
-
 # create_database()
 db = next(get_db())
 
@@ -34,13 +28,15 @@ org_2.users.extend([user_1, user_3])
 org_3.users.extend([user_2, user_1])
 db.commit()
 
-product_1 = Product(name="bed", price=400000, org_id=org_1.id)
-product_2 = Product(name="shoe", price=150000, org_id=org_2.id)
+product_1 = Product(name="bed", price=400000, description="test product 1", org_id=org_1.id)
+product_2 = Product(name="shoe", price=150000, description="test product 2", org_id=org_2.id)
+product_3 = Product(name="choco", price=2000, description="test product 3", org_id=org_3.id)
+product_4 = Product(name="Latte", price=29000, description="test product 4", org_id=org_3.id)
 
 profile_1 = Profile(bio='My name is John Doe', phone_number='09022112233')
 user_1.profile = profile_1
 
-db.add_all([product_1, product_2])
+db.add_all([product_1, product_2, product_3, product_4])
 db.commit()
 users = db.query(Organization).first().users
 print("Seed data succesfully")

--- a/tests/v1/org_products_test.py
+++ b/tests/v1/org_products_test.py
@@ -1,0 +1,153 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from api.v1.services.user import user_service
+from sqlalchemy.orm import Session
+from api.db.database import get_db
+from api.v1.models import User, Product, Organization
+from api.v1.services.user import user_service
+from uuid_extensions import uuid7
+from unittest.mock import MagicMock
+
+client = TestClient(app)
+
+# Mock database
+@pytest.fixture
+def mock_db_session(mocker):
+    db_session_mock = mocker.MagicMock(spec=Session)
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    return db_session_mock
+
+# Test User
+@pytest.fixture
+def test_user():
+    return User(
+        id=str(uuid7()),
+        username="testuser",
+        email="testuser@gmail.com",
+        password="hashedpassword",
+        first_name="test",
+        last_name="user",
+        is_active=True,
+    )
+
+# Another Test User
+@pytest.fixture
+def another_user():
+    return User(
+        id=str(uuid7()),
+        username="anotheruser",
+        email="anotheruser@gmail.com",
+        password="hashedpassword",
+        first_name="another",
+        last_name="user",
+        is_active=True,
+    )
+
+@pytest.fixture
+def test_organization(test_user):
+    organization = Organization(
+        id=str(uuid7()),
+        name="testorg",
+        description="An organization for testing purposes"
+    )
+    organization.users.append(test_user)
+    return organization
+
+@pytest.fixture()
+def test_product(test_organization):
+    return Product(
+        id=str(uuid7()),
+        name="testproduct",
+        description="Test product",
+        price=9.99,
+        org_id=test_organization.id
+    )
+
+@pytest.fixture
+def access_token_user1(test_user):
+    return user_service.create_access_token(user_id=test_user.id)
+
+@pytest.fixture
+def access_token_user2(another_user):
+    return user_service.create_access_token(user_id=another_user.id)
+
+# Test for User in Organization
+def test_get_products_for_organization_user_belongs(
+    mock_db_session, 
+    test_user, 
+    test_organization, 
+    test_product,
+    access_token_user1,
+):
+    # Mock the GET method for Organization
+    def mock_get(model, ident):
+        if model == Organization and ident == test_organization.id:
+            return test_organization
+        return None
+
+    mock_db_session.get.side_effect = mock_get
+
+    # Mock the query for checking if user is in the organization
+    mock_db_session.query.return_value.filter.return_value.first.return_value = test_user
+
+    # Mock the query for products
+    mock_db_session.query.return_value.filter.return_value.all.return_value = [test_product]
+
+    # Test user belonging to the organization
+    headers = {'Authorization': f'Bearer {access_token_user1}'}
+    response = client.get(f"/api/v1/products/{test_organization.id}", headers=headers)
+    
+    # Debugging statement
+    if response.status_code != 200:
+        print(response.json())  # Print error message for more details
+
+    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
+    # products = response.json().get('data', [])
+
+### Test for user not in Organization
+def test_get_products_for_organization_user_not_belong(
+    mock_db_session, 
+    another_user, 
+    test_organization, 
+    test_product,
+    access_token_user2,
+):
+    # Ensure the organization does not contain another_user
+    test_organization.users = []
+
+    # Mock the `get` method for `Organization`
+    def mock_get(model, ident):
+        if model == Organization and ident == test_organization.id:
+            return test_organization
+        return None
+
+    mock_db_session.get.side_effect = mock_get
+
+    # Mock the query for checking if user is in the organization
+    mock_db_session.query.return_value.filter.return_value.first.return_value = another_user
+
+    # Test user not belonging to the organization
+    headers = {'Authorization': f'Bearer {access_token_user2}'}
+    response = client.get(f"/api/v1/products/{test_organization.id}", headers=headers)
+    
+    assert response.status_code == 400, f"Expected status code 400, got {response.status_code}"
+
+### Test for non-existent Organization
+def test_get_products_for_non_existent_organization(
+    mock_db_session, 
+    test_user, 
+    access_token_user1,
+):
+    # Mock the `get` method for `Organization` to return None for non-existent ID
+    def mock_get(model, ident):
+        return None
+
+    mock_db_session.get.side_effect = mock_get
+
+    # Test non-existent organization
+    non_existent_id = "non-existent-id"  # Use a string since the IDs are UUIDs
+    headers = {'Authorization': f'Bearer {access_token_user1}'}
+    response = client.get(f"/api/v1/products/{non_existent_id}", headers=headers)
+    
+    assert response.status_code == 404, f"Expected status code 404, got {response.status_code}"


### PR DESCRIPTION
I added the fetch organization products list enpoint to the route of the project at `/api/v1/products/{org_id}?limit=10&page=1`

## Description

This endpoint fetches all products of an organization. Only authenticated `users` who are `members` of the `organization request id` can successfully fetch data from the endpoint. Any other user gets a `400 error` for authenticated users and `401 unauthorized error` for unauthenticated users. 
The search results can futher be filtered with the `limit` and `page` query parameter. These are used to calculate offsets and page limits furthering improving users experience when dealing with a large volume of data. 

## Related Issue (Link to issue ticket)

The issue for this pull request can be found [here](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/380).

## Motivation and Context

This endpoint helps to streamline the protection of each organizations data, only members of the organization have access to the data. 

## How Has This Been Tested?

The endpoint has been tested. The unit tests are in the file `/tests/v1/org_products_test.py`.
- [x] Data is fetched appropriately from the database.
- [x] Appropriate response and status code is returned. 
- [x] Users must be authenticated.
- [x] Non existing `org_id` will throw a `404` error. 
- [x] Attempt to access by non-members will throw an error too. 
- [x] Users can indicate limit number and page number with fallbacks set to 10 and 1 for each. Neither must be 0 or less.

The test can be run by: ` PYTHONPATH=. pytest tests/v1/org_products_test.py `.

### Affected areas of the code
- I added a `product.py` file to the route and schema folders. The files outline the model for my response data and logic for the endpoint respectively. 
- I also added more codes to the `/service/product.py` files.
- I added a test file at `tests/v1/org_products_test.py`.

## Screenshots (if appropriate - Postman, etc):
### Success Response
![Screenshot from 2024-07-24 21-45-36](https://github.com/user-attachments/assets/aee15c36-ebbd-48d6-a55c-9bcc89ec878e)


### Non member access response
![Screenshot from 2024-07-24 13-33-49](https://github.com/user-attachments/assets/27524daf-667e-4df2-91df-33831fffa912)

### Unauthenticated user response
![Screenshot from 2024-07-24 13-34-03](https://github.com/user-attachments/assets/6613c77d-1741-485e-9b00-4ed2bf592b45)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)    ​

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the readme accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
