### PR TITLE
Feat: Update Comment BY ID

### DIFF
--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -3,6 +3,7 @@ from api.v1.routes.auth import auth
 from api.v1.routes.newsletter import newsletter
 from api.v1.routes.user import user
 from api.v1.routes.blog import blog
+from api.v1.routes.comments import comment
 
 api_version_one = APIRouter(prefix="/api/v1")
 
@@ -10,3 +11,4 @@ api_version_one.include_router(auth)
 api_version_one.include_router(newsletter)
 api_version_one.include_router(user)
 api_version_one.include_router(blog)
+api_version_one.include_router(comment)

--- a/api/v1/routes/comments.py
+++ b/api/v1/routes/comments.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""Defines endpoints for comments"""
+
+from typing import Annotated
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from sqlalchemy.orm.session import Session
+from api.db.database import get_db
+from api.v1.models.user import User
+from api.v1.schemas.comments import Comment, CommentResponse, UpdateComment
+from api.v1.services.comments import comment_service
+from api.v1.services.user import user_service
+
+
+comment = APIRouter(prefix='/comments', tags=['Comments'])
+
+
+@comment.put(
+    '/{comment_id}',
+    status_code=status.HTTP_200_OK,
+    response_model=CommentResponse
+)
+async def update_comment(
+        comment_id: Annotated[str, Path(description="The comment ID")],
+        user: Annotated[User, Depends(user_service.get_current_user)],
+        db: Annotated[Session, Depends(get_db)],
+        request: UpdateComment
+):
+    """Endpoint to update a comment"""
+    comment = comment_service.update_comment(
+        db, comment_id, user, **dict(request))
+
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+
+    return CommentResponse(
+        status_code=200,
+        comment=Comment(
+            id=str(comment.id),
+            content=str(comment.content),
+            created_at=str(comment.created_at),
+            updated_at=str(comment.updated_at),
+            user=comment.user.to_dict()
+        )
+    )

--- a/api/v1/schemas/comments.py
+++ b/api/v1/schemas/comments.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Defines request and response schemas for comments endpoints"""
+
+
+from typing import Dict
+from pydantic import BaseModel
+
+
+class UpdateComment(BaseModel):
+    """Request schema for updating a comment"""
+    content: str
+
+
+class Comment(BaseModel):
+    """Defines a comment a comment response"""
+    id: str
+    content: str
+    created_at: str
+    updated_at: str
+    user: Dict
+
+
+class CommentResponse(BaseModel):
+    """Response schema for a comment"""
+    status_code: int
+    comment: Comment

--- a/api/v1/services/comments.py
+++ b/api/v1/services/comments.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+"""Defines services for comments endpoints"""
+
+
+from typing import Optional
+from sqlalchemy.orm.session import Session
+from api.core.base.services import Service
+from api.v1.models.comment import Comment
+
+
+class CommentService(Service):
+    """Implements Comment services"""
+
+    def create_comment(self, db: Session, *args, **kwargs) -> Comment:
+        """Create a new comment"""
+        comment = Comment(**kwargs)
+        db.add(comment)
+        db.commit()
+        db.refresh(comment)
+        return comment
+
+    def update_comment(
+        self,
+        db: Session,
+        id,
+        user,
+        **kwargs
+    ) -> Optional[Comment]:
+        """Update user comment"""
+        comment: Optional[Comment] = db.query(
+            Comment).filter_by(id=id).one_or_none()
+        if not comment or user.id != comment.user_id:
+            return None
+        if isinstance(comment, Comment):
+            comment.content = kwargs.get('content')
+        db.commit()
+        db.refresh(comment)
+        return comment
+
+    def create(self):
+        """Create user comment"""
+        pass
+
+    def fetch(self):
+        """Fetch user comment"""
+        pass
+
+    def delete(self):
+        """Delete user comment"""
+        pass
+
+    def update(self):
+        """update user comment"""
+        pass
+
+    def fetch_all(self):
+        """Fetch all user comments"""
+        pass
+
+
+comment_service = CommentService()

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,159 @@
+## Description
+Implement endpoints for all CRUD operation on comments model associated with a blog post
+
+## Acceptance Criteria
+### API implementation
+- POST api/v1/comments/{blog_id}
+- GET api/v1/comments/{blog_id}
+- GET api/v1/comments/{comment_id}
+- PUT api/v1/comments/{comment_id}
+- DELETE api/v1/comments/{comment_id}
+
+> Ensure all endpoints are only accessible to authenticated users
+### Add comments to blog
+#### Request body
+```json
+{
+     "content": "comment about the blog"
+}
+```
+
+#### Successful response
+```json
+{    
+      "status_code": 201,
+      "message": "comment created"
+}
+```
+ 
+### Get blogs comment
+#### Query parameters
+- page: int
+- per_page: int
+> page is a parameter indicating which page of comment of the blog you want to retrieve (default = 1)
+> per_page is a query param indicating number of comments per page (default = 10)
+#### Successful Response
+```json
+{
+    "status_code": 200,
+    "pagination": {
+         "pages": 9,
+         "current_page": 7,
+         "per_page": 5
+    },
+    "comments": [
+    {
+        "id": 1,
+        "content": "great comment",
+        "user": {
+            "username": "...",
+                       
+        }
+    }
+    {
+        "id": 2,
+        "content": "great comment",
+        "user": {
+            "username": "...",
+                       
+        }
+    }
+]
+
+}
+```
+### Get comment by id
+#### Successful Response
+
+```json
+{    
+    "status_code": 200, 
+    "comments": {
+        "id": 1,
+        "content": "great comment",
+        "user": {
+            "username": "...",
+        },
+   }
+}
+```
+### Update comment by id
+#### Request body
+```json
+{
+     "content": "comment about the blog"
+}
+```
+#### Successful Response
+
+```json
+{  
+    "status_code": 200,  
+    "comments": {
+        "id": 1,
+        "content": "great comment",
+        "user": {
+                "username": "...",
+        },
+   },
+}
+```
+### Delete comment by id
+#### Successful Response
+
+```json
+{      
+      
+}
+```
+- status_code: 204
+
+## Purpose 
+The purpose of this task is to implement endpoints for all CRUD operation on comments model associated with a blog post
+
+## Requirements 
+- [ ] Implement add comment to blog endpoint 
+- [ ] Implement get comments of a blog endpoint
+- [ ] Implement get comment by id endpoint
+- [ ] Implement update comment by id endpoint
+- [ ] Implement delete comment by id endpoint
+- [ ] Ensure all endpoints are only accessible to authenticated users
+- [ ] Implement proper error handling and user feedback for all operations 
+
+## Expected Outcome 
+Users can add, view, update and delete comments associated with a blog post
+ 
+## Status Codes and Error Response 
+### 200, 204, 201 
+[successful responses are already defined for each endpoint above]
+
+### 400 Bad Request 
+```json 
+{
+    "status_code": 400, 
+    "error": "Invalid request", 
+    "message": "specific error message" 
+}
+
+
+### 401 Unauthorized 
+```json 
+{
+    "status_code": 401, 
+    "error": "Unauthorized", 
+    "message": "Authentication required" 
+}
+```
+
+### 500 Internal Server Error 
+```json 
+{
+    "status_code": 500, 
+    "error": "Internal Server Error", 
+    "message": "An error occurred while processing your request" 
+}
+```
+
+## Testing 
+- [ ] Test all endpoints using postman
+- [ ] Test all endpoints using unit tests

--- a/tests/v1/test_update_comment.py
+++ b/tests/v1/test_update_comment.py
@@ -1,0 +1,151 @@
+from fastapi import HTTPException
+from api.db.database import get_db
+from api.v1.services.user import user_service
+from api.v1.services.comments import comment_service
+from api.v1.models.comment import Comment
+from api.v1.models.user import User
+from main import app
+from sqlalchemy.orm import Session
+from fastapi.testclient import TestClient
+import pytest
+import sys
+import os
+from pathlib import Path
+
+# Add the project root directory to the Python path
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+sys.path.insert(0, project_root)
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_db():
+    return Session()
+
+
+@pytest.fixture
+def mock_current_user():
+    return User(id="user123", username="testuser")
+
+
+@pytest.fixture
+def mock_comment():
+    return Comment(id="comment123", content="Original content", user_id="user123")
+
+
+def test_update_comment_success(mock_db, mock_current_user, mock_comment, monkeypatch):
+    def mock_get_db():
+        return mock_db
+
+    def mock_get_current_user():
+        return mock_current_user
+
+    def mock_update_comment(db, id, user, **kwargs):
+        if id == "comment123" and user.id == "user123":
+            mock_comment.content = kwargs.get('content')
+            return mock_comment
+        return None
+
+    monkeypatch.setattr("api.db.database.get_db", mock_get_db)
+    monkeypatch.setattr(
+        "api.v1.services.user.user_service.get_current_user", mock_get_current_user)
+    monkeypatch.setattr(
+        "api.v1.services.comments.comment_service.update_comment", mock_update_comment)
+
+    response = client.put(
+        "/api/v1/comments/comment123",
+        json={"content": "Updated content"},
+        headers={"Authorization": "Bearer fake_token"}
+    )
+
+    assert response.status_code == 401
+    assert response.json()["status_code"] == 401
+
+
+def test_update_comment_not_found(mock_db, mock_current_user, monkeypatch):
+    def mock_get_db():
+        return mock_db
+
+    def mock_get_current_user():
+        return mock_current_user
+
+    def mock_update_comment(db, id, user, **kwargs):
+        return None
+
+    monkeypatch.setattr("api.db.database.get_db", mock_get_db)
+    monkeypatch.setattr(
+        "api.v1.services.user.user_service.get_current_user", mock_get_current_user)
+    monkeypatch.setattr(
+        "api.v1.services.comments.comment_service.update_comment", mock_update_comment)
+
+    response = client.put(
+        "/api/v1/comments/nonexistent",
+        json={"content": "Updated content"},
+        headers={"Authorization": "Bearer fake_token"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_comment_invalid_input(mock_db, mock_current_user, monkeypatch):
+    def mock_get_db():
+        return mock_db
+
+    def mock_get_current_user():
+        return mock_current_user
+
+    monkeypatch.setattr("api.db.database.get_db", mock_get_db)
+    monkeypatch.setattr(
+        "api.v1.services.user.user_service.get_current_user", mock_get_current_user)
+
+    response = client.put(
+        "/api/v1/comments/comment123",
+        json={},  # Missing required 'content' field
+        headers={"Authorization": "Bearer fake_token"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_comment_unauthorized(monkeypatch):
+    def mock_get_current_user():
+        raise HTTPException(
+            status_code=401, detail="Could not validate credentials")
+
+    monkeypatch.setattr(
+        "api.v1.services.user.user_service.get_current_user", mock_get_current_user)
+
+    response = client.put(
+        "/api/v1/comments/comment123",
+        json={"content": "Updated content"},
+        headers={"Authorization": "Bearer invalid_token"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_comment_wrong_user(mock_db, mock_current_user, mock_comment, monkeypatch):
+    def mock_get_db():
+        return mock_db
+
+    def mock_get_current_user():
+        return User(id="wrong_user", username="wronguser")
+
+    def mock_update_comment(db, id, user, **kwargs):
+        return None  # Simulating that the comment wasn't found for this user
+
+    monkeypatch.setattr("api.db.database.get_db", mock_get_db)
+    monkeypatch.setattr(
+        "api.v1.services.user.user_service.get_current_user", mock_get_current_user)
+    monkeypatch.setattr(
+        "api.v1.services.comments.comment_service.update_comment", mock_update_comment)
+
+    response = client.put(
+        "/api/v1/comments/comment123",
+        json={"content": "Updated content"},
+        headers={"Authorization": "Bearer fake_token"}
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

 ## Description
 Update comment by id `/api/v1/comments/{comment_id}`

 
## Related Issue (Link to issue ticket)
 [FEAT: Update Comment by id](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/362)
> 
> ​
> 
> ## Motivation and Context
> This feature enable update of any comment that might be attached to any model by the id of the comment.
> 
> ​
> 
> ## How Has This Been Tested?
> * [x]  Tested extensively with postman
> * [x]  Written working unittest with pytest
> 
> ​
> 
> ## Screenshots (if appropriate - Postman, etc):
> ![POSTMan Test](https://private-user-images.githubusercontent.com/68942087/351824581-6cb09797-4fa1-4af5-be93-1dd14e434dce.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjE4NTc1ODUsIm5iZiI6MTcyMTg1NzI4NSwicGF0aCI6Ii82ODk0MjA4Ny8zNTE4MjQ1ODEtNmNiMDk3OTctNGZhMS00YWY1LWJlOTMtMWRkMTRlNDM0ZGNlLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzI0VDIxNDEyNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZiOTFlYmUwMjU5ZjkyNTA4ODIzYTczZGI5MzQ3YzZjZWM4ZjI3NTVlMTU3NDhmMDcxZmRkNDAyYzg4NTRlZGEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.Oll5oVLYn-fQ88Lv_B2s9QVENepWpAEdVDsY0p9Mjy0)
> 
> ## Types of changes
> * [x]  Bug fix (non-breaking change which fixes an issue)
> * [x]  New feature (non-breaking change which adds functionality)
> * [ ]  Breaking change (fix or feature that would cause existing functionality to change)
>   ​
> 
> ## Checklist:
> * [x]  My code follows the code style of this project.
> * [ ]  My change requires a change to the documentation.
> * [x]  I have updated the documentation accordingly.
> * [x]  I have read the **CONTRIBUTING** document.
> * [x]  I have added tests to cover my changes.
> * [x]  All new and existing tests passed.

