### PR TITLE
added a route for deleting a testimonial

### DIFF
--- a/api/v1/routes/testimonial.py
+++ b/api/v1/routes/testimonial.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Module contains CRUD routes for testimonial
+"""
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
+from api.db.database import get_db
+from sqlalchemy.orm import Session
+from api.utils.dependencies import get_current_admin
+from api.v1.models.user import User
+from api.v1.models.testimonial import Testimonial
+from uuid import UUID
+
+testmonial_route = APIRouter(tags=["testimonials"])
+
+@testmonial_route.delete("/testimonials/{testimonial_id}")
+def delete_testimonial(
+    testimonial_id: UUID,
+    current_user: User = Depends(get_current_admin),
+    db: Session = Depends(get_db)
+):
+    """
+    Function for deleting a testimonial based on testimonial id
+    """
+    testimonial = db.query(Testimonial).filter(Testimonial.id == testimonial_id).first()
+    if not testimonial:
+        raise HTTPException(
+            detail="Testimonial not found",
+            status_code=status.HTTP_404_NOT_FOUND
+        )
+    db.delete(testimonial)
+    db.commit()
+    return JSONResponse(
+        content={
+            "success": True,
+            "message": "Testimonial deleted successfully",
+            "status_code": status.HTTP_200_OK
+        },
+        status_code=status.HTTP_200_OK
+    )

--- a/tests/v1/test_testimonial_delete.py
+++ b/tests/v1/test_testimonial_delete.py
@@ -1,0 +1,139 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+from datetime import timedelta
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from api.db.database import Base, get_db
+from main import app
+from api.v1.models.testimonial import Testimonial
+from sqlalchemy.ext.declarative import declarative_base
+from api.v1.models.user import User
+from decouple import config
+from api.v1.services.user import user_service
+from uuid_extensions import uuid7
+import pytest
+
+
+DATABASE_URL = config("DATABASE_URL_TEST")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture()
+def session():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def client(session):
+    def override_get_db():
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+
+
+
+
+@pytest.fixture
+def setup(request, session):
+    print("\nSetting up resources...")
+    db = session
+    hashed_password = user_service.hash_password("adminpassword")
+    admin_user = User(
+        username="admin",
+        email="admin@example.com",
+        password=hashed_password,
+        first_name="Admin",
+        last_name="User",
+        is_super_admin=True,
+        is_active=True,
+    )
+    db.add(admin_user)
+    db.commit()
+    db.refresh(admin_user)
+
+    admin_token = user_service.create_access_token(admin_user.id)
+
+    testimonial = Testimonial(
+        client_name="John",
+        content="Hello WOrld",
+        author_id=admin_user.id
+        )
+    db.add(testimonial)
+    db.commit()
+    db.refresh(testimonial)
+
+    # Define a finalizer function for teardown
+    def finalizer():
+        print("\nPerforming teardown...")
+        db.query(Testimonial).delete()
+        db.query(User).delete()
+        db.commit()
+        db.close()
+
+    # Register the finalizer to ensure cleanup
+    request.addfinalizer(finalizer)
+
+    return {
+        "admin_user": admin_user,
+        "testimonial": testimonial,
+        "admin_token": admin_token,
+    }
+
+
+def test_delete_existing_testimonial(
+    client: TestClient, setup
+):
+    testimonial = setup["testimonial"]
+    admin_token = setup["admin_token"]
+
+    response = client.delete(
+        f"/api/v1/testimonials/{testimonial.id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "message": "Testimonial deleted successfully",
+        "status_code": 200,
+    }
+
+
+def test_delete_non_existent_testimonial(
+    client: TestClient, setup
+):
+    non_existent_id = uuid7()
+    admin_token = setup["admin_token"]
+    response = client.delete(
+        f"/api/v1/testimonials/{non_existent_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Testimonial not found"}
+
+
+def test_delete_testimonial_without_authentication(
+    client: TestClient, setup
+    ):
+    testimonial = setup["testimonial"]
+    response = client.delete(f"/api/v1/testimonials/{testimonial.id}")
+
+    assert response.status_code == 401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description
This PR adds an API endpoint to handle the deletion of a testimonial, it requires users to be admin and authenticated before access
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)
 [FEAT]: API Endpoint to delete a testimonial #131 
​

## Motivation and Context
This route enables deleting of a testimonial based on the testimonial ID

​

## How Has This Been Tested?

- Pytest
- Tested the Endpoint with Swagger UI
​​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Added a route that deletes a testimonial from the db
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
