### PR TITLE
Feat: Org - Get all users in an organization #332

### DIFF
--- a/api/utils/dependencies.py
+++ b/api/utils/dependencies.py
@@ -15,6 +15,7 @@ from .config import SECRET_KEY, ALGORITHM
 # Initialize OAuth2PasswordBearer
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
+
 def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -3,6 +3,7 @@ from api.v1.routes.auth import auth
 from api.v1.routes.newsletter import newsletter
 from api.v1.routes.user import user
 from api.v1.routes.blog import blog
+from api.v1.routes.org import org
 
 api_version_one = APIRouter(prefix="/api/v1")
 
@@ -10,3 +11,4 @@ api_version_one.include_router(auth)
 api_version_one.include_router(newsletter)
 api_version_one.include_router(user)
 api_version_one.include_router(blog)
+api_version_one.include_router(org)

--- a/api/v1/routes/org.py
+++ b/api/v1/routes/org.py
@@ -1,0 +1,50 @@
+from fastapi import Depends, HTTPException, APIRouter, status
+from sqlalchemy.orm import Session
+from api.utils.success_response import success_response
+from api.v1.models.user import User
+from api.db.database import get_db
+from api.v1.services.user import user_service
+from uuid_extensions import uuid7
+from uuid import UUID
+from ..schemas.org import OrganizationUsersResponse
+from ..models.org import Organization
+from ..models.user import User
+
+org = APIRouter(prefix='/organizations', tags=['Organization'])
+
+
+
+
+@org.get("/{org_id}/users", status_code=status.HTTP_200_OK)
+async def get_organization_users(
+    org_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user) 
+):
+    """Retrieve all users in an organisation"""
+    # Check if the organization exists
+    org = db.query(Organization).filter(Organization.id == str(org_id)).first()
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    # Check if the current user has access to this organization
+    user =  any(user.id == current_user.id for user in org.users)
+
+    if not user:
+        raise HTTPException(status_code=403, detail="You don't have access to this organization")
+
+    # Fetch users from the database
+    users = org.users
+
+    # If no users found, raise an HTTPException
+    if not users:
+        return []
+
+    # Create the response
+    response = OrganizationUsersResponse(org_id=org_id, users=users)
+
+    return {
+        "status": "200",
+        "message": "organization users retrieved successfully",
+        "data": response.model_dump()
+    }

--- a/api/v1/schemas/org.py
+++ b/api/v1/schemas/org.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from uuid_extensions import uuid7
+from uuid import UUID
+from .user import UserBase
+from typing import List
+
+
+class OrganizationUsersResponse(BaseModel):
+    org_id: UUID
+    users: List[UserBase]
+
+    class Config:
+        from_attributes = True

--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -15,6 +15,9 @@ class UserBase(BaseModel):
     email: EmailStr
     created_at: datetime
 
+    class Config:
+        from_attributes = True
+
 class UserCreate(BaseModel):
     '''Schema to create a user'''
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,6 @@ typer==0.12.3
 typing_extensions==4.12.2
 uuid7==0.1.0
 uvicorn==0.30.3
-uvloop==0.19.0
+#uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0

--- a/tests/v1/get_org_users_test.py
+++ b/tests/v1/get_org_users_test.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+from main import app
+import pytest
+from uuid import UUID
+from api.v1.services.user import user_service
+
+client = TestClient(app)
+
+# Mock valid and invalid tokens
+VALID_TOKEN = "valid_token"
+INVALID_TOKEN = "invalid_token"
+
+# Mock user data
+MOCK_USER = {
+    "id": UUID("11111111-1111-1111-1111-111111111111"),
+    "email": "user@example.com",
+    "name": "John Doe",
+    "role": "Admin"
+}
+
+# Mock function to validate token and return user
+def mock_get_current_user(token: str):
+    if token == VALID_TOKEN:
+        return MOCK_USER
+    raise HTTPException(status_code=401, detail="Invalid token")
+
+# Apply the mock to your dependency
+app.dependency_overrides[user_service.get_current_user] = mock_get_current_user
+
+
+def test_get_organization_users_success():
+    org_id = "066a1121-b805-7393-8002-e20f2105f59c"
+    response = client.get(f"/api/v1/organization/{org_id}/users", headers={"Authorization": f"Bearer {VALID_TOKEN}"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["org_id"] == org_id
+    assert len(data["users"]) > 0
+    assert all(key in data["users"][0] for key in ["id", "email", "name", "role"])
+
+def test_get_organization_users_invalid_uuid():
+    org_id = "invalid-uuid"
+    response = client.get(f"/api/v1/organization/{org_id}/users", headers={"Authorization": f"Bearer {VALID_TOKEN}"})
+    assert response.status_code == 422
+
+def test_get_organization_users_no_auth():
+    org_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    response = client.get(f"/api/v1/organization/{org_id}/users")
+    assert response.status_code == 401 
+
+def test_get_organization_users_invalid_token():
+    org_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    response = client.get(f"/api/v1/organization/{org_id}/users", headers={"Authorization": f"Bearer {INVALID_TOKEN}"})
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid token"


### PR DESCRIPTION
This PR contains the implementation of `[GET] /api/v1/organization/{org_id}/users` [PROTECTED Endpoint]

## Description

Added functionality for retrieving all users in an organization. This includes creating an endpoint `/api/v1/organization/{org_id}/users` that fetches all users in an organization from the database. The endpoint returns a list of users, each containing details such as first_name, last_name, username, email, etc.

## Related Issue (Link to issue ticket)
This is an implementation of an open issue #332 

## Motivation and Context

This feature  is required to provide an endpoint for users who are members of an organization to view all other users in the organization.

## How Has This Been Tested?

The new functionality has been tested using pytest, FastAPI test client, Postman and manual testing. Tests include:
- Retrieving all users in an organization the user belongs to
- Test cases for authentication and authorization
- Test cases for error scenarios (invalid UUID, organization not found, etc.)

Test environment:
- PostgreSQL database for storing blog information.
- Mock database setup using pytest for isolated testing.
- Test client setup using FastAPI for API endpoint testing.

## Screenshots (if appropriate - Postman, etc):

###Successful response - Postman
![postman](https://github.com/user-attachments/assets/6ef5a2e5-88cb-4e12-9181-05b44155a584)

###FastAPI - OpenAPI
![OpenAPI](https://github.com/user-attachments/assets/72adecb1-4b0c-4d53-ac92-4574d568cb9f)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
