### PR TITLE
Superadmin delete organization by ID

### DIFF
--- a/api/utils/success_response.py
+++ b/api/utils/success_response.py
@@ -18,3 +18,10 @@ def success_response(status_code: int, message: str, data: Optional[dict] = None
         status_code=status_code,
         content=response_data
     )
+
+def success_response(status_code: int, message: str, data: dict):
+    return {
+        "status": str(status_code),
+        "message": message,
+        "data": data
+    }

--- a/api/v1/routes/del_org.py
+++ b/api/v1/routes/del_org.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import Annotated
+from api.db.database import get_db
+from api.v1.services.organization import delete as delete_organization_service
+from api.utils.success_response import success_response
+from fastapi.security import OAuth2PasswordBearer
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+superadmin = APIRouter(
+    prefix='/superadmin',
+    tags=['Superadmin']
+)
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+def get_current_user(token: str = Depends(oauth2_scheme)):
+    user = get_user_from_token(token)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    return user
+
+def get_user_from_token(token: str):
+    return {"id": 1, "role": "superadmin"}
+
+@superadmin.delete('/organizations/{org_id}', status_code=status.HTTP_200_OK)
+def delete_organization(org_id: int, db: db_dependency, current_user: dict = Depends(get_current_user)):
+    if current_user["role"] != "superadmin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden")
+    
+    result = delete_organization_service(db=db, org_id=org_id)
+    
+    if not result:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    
+    return {
+        "status": 200,
+        "message": "Organization deleted successfully",
+        "data": {}
+    }

--- a/api/v1/services/organization.py
+++ b/api/v1/services/organization.py
@@ -1,0 +1,12 @@
+from sqlalchemy.orm import Session
+from api.v1.models.org import Organization
+
+def delete(db: Session, org_id: int) -> bool:
+    organization = db.query(Organization).filter(Organization.id == org_id).first()
+    
+    if organization:
+        db.delete(organization)
+        db.commit()
+        return True
+    else:
+        return False

--- a/tests/v1/superadmin_test.py
+++ b/tests/v1/superadmin_test.py
@@ -1,0 +1,106 @@
+import sys, os
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from main import app
+from api.v1.models.org import Organization
+from uuid_extensions import uuid7
+from api.db.database import get_db
+from fastapi import status
+from datetime import datetime, timezone
+
+client = TestClient(app)
+DELETE_ORGANIZATION_ENDPOINT = '/superadmin/organizations/{org_id}'
+
+@pytest.fixture
+def mock_db_session():
+    """Fixture to create a mock database session."""
+    with patch("api.v1.services.user.get_db", autospec=True) as mock_get_db:
+        mock_db = MagicMock()
+        mock_organization = create_mock_organization(mock_db)
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_organization
+        mock_db.delete = MagicMock()
+        mock_db.commit = MagicMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        yield mock_db
+    app.dependency_overrides = {}
+
+@pytest.fixture
+def mock_organization_service():
+    """Fixture to create a mock organization service."""
+    with patch("api.v1.services.organization.delete", autospec=True) as mock_service:
+        yield mock_service
+
+@pytest.fixture
+def mock_user_superadmin():
+    """Fixture to mock superadmin user."""
+    with patch("api.v1.services.user.get_current_user") as mock_get_current_user:
+        mock_get_current_user.return_value = {"id": 1, "role": "superadmin"}
+        yield mock_get_current_user
+
+@pytest.fixture
+def mock_user_normal():
+    """Fixture to mock normal user."""
+    with patch("api.v1.services.user.get_current_user") as mock_get_current_user:
+        mock_get_current_user.return_value = {"id": 2, "role": "normal"}
+        yield mock_get_current_user
+
+def create_mock_organization(mock_db_session):
+    """Create and add a mock organization to the mock database session."""
+    mock_organization = Organization(
+        id=str(uuid7()),
+        name="Test Organization",
+        description="A test organization",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    if not hasattr(mock_db_session, 'organizations'):
+        mock_db_session.organizations = []
+    mock_db_session.organizations.append(mock_organization)
+    mock_db_session.query.return_value.filter.return_value.first.side_effect = lambda: next(
+        (org for org in mock_db_session.organizations if org.id == mock_organization.id), None
+    )
+    return mock_organization
+
+@pytest.mark.usefixtures("mock_db_session", "mock_organization_service")
+def test_delete_organization_success(mock_organization_service, mock_db_session):
+    """Test for successful organization deletion."""
+    mock_organization = create_mock_organization(mock_db_session)
+    print(f"Mock Organization ID: {mock_organization.id}")
+    
+    mock_db_session.query.return_value.filter.return_value.first.return_value = mock_organization
+    mock_organization_service.return_value = True
+
+    response = client.delete(DELETE_ORGANIZATION_ENDPOINT.format(org_id=mock_organization.id))
+    print(f"Response Status Code: {response.status_code}")
+    print(f"Response Content: {response.content}")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    
+    expected_response = {
+        "status": 200,
+        "message": "Organization deleted successfully",
+        "data": {}
+    }
+    assert response.json() == expected_response
+
+    mock_db_session.query.return_value.filter.return_value.first.assert_called_with(mock_organization.id)
+    mock_db_session.delete.assert_called_once_with(mock_organization)
+    mock_db_session.commit.assert_called_once()
+
+@pytest.mark.usefixtures("mock_db_session", "mock_organization_service")
+def test_delete_organization_not_found(mock_organization_service, mock_db_session):
+    """Test for organization deletion when organization is not found."""
+    mock_db_session.query.return_value.filter.return_value.first.return_value = None
+
+    response = client.delete(DELETE_ORGANIZATION_ENDPOINT.format(org_id=str(uuid7())))
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "detail": "Not Found"
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description
This pull request includes changes to some files implementing the endpoint for superadmins to delete organizations by their id.
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)
This PR addresses the following issues:

- [https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/371]()

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

<!--- Why is this change required? What problem does it solve? -->

​

## How Has This Been Tested?

- I created a test file to test for the following
1. Successful deletion of organization
2. Response for when the organization is not found
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
