### PR TITLE
feat: create activity log

### DIFF
--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -14,6 +14,7 @@ from api.v1.routes.google_login import google_auth
 from api.v1.routes.invitations import invites
 from api.v1.routes.profiles import profile
 from api.v1.routes.request_password import pwd_reset
+from api.v1.routes.activity_logs import activity_logs
 
 api_version_one = APIRouter(prefix="/api/v1")
 
@@ -32,3 +33,4 @@ api_version_one.include_router(google_auth)
 api_version_one.include_router(invites)
 api_version_one.include_router(profile)
 api_version_one.include_router(pwd_reset)
+api_version_one.include_router(activity_logs)

--- a/api/v1/routes/activity_logs.py
+++ b/api/v1/routes/activity_logs.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, status
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy.orm import Session
+from api.v1.schemas.activity_logs import ActivityLogCreate
+from api.v1.services.activity_logs import activity_log_service
+from api.db.database import get_db
+from api.utils.success_response import success_response
+
+activity_logs = APIRouter(prefix="/activity-logs", tags=["Activity Logs"])
+
+@activity_logs.post("/create", status_code=status.HTTP_201_CREATED)
+async def create_activity_log(activity_log: ActivityLogCreate, db: Session = Depends(get_db)):
+    '''Create a new activity log'''
+
+    new_activity_log = activity_log_service.create_activity_log(
+        db=db, 
+        user_id=activity_log.user_id, 
+        action=activity_log.action
+    )
+
+    return success_response(
+        status_code=201,
+        message="Activity log created successfully",
+        data= jsonable_encoder(new_activity_log)
+    )

--- a/api/v1/schemas/activity_logs.py
+++ b/api/v1/schemas/activity_logs.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class ActivityLogCreate(BaseModel):
+    user_id: int
+    action: str

--- a/api/v1/services/activity_logs.py
+++ b/api/v1/services/activity_logs.py
@@ -1,0 +1,16 @@
+from sqlalchemy.orm import Session
+from api.v1.models.activity_logs import ActivityLog
+
+class ActivityLogService:
+    '''Activity Log service'''
+
+    def create_activity_log(self, db: Session, user_id: int, action: str):
+        '''Creates a new activity log'''
+
+        activity_log = ActivityLog(user_id=user_id, action=action)
+        db.add(activity_log)
+        db.commit()
+        db.refresh(activity_log)
+        return activity_log
+
+activity_log_service = ActivityLogService()

--- a/tests/v1/activity_logs/test_create_activity_log.py
+++ b/tests/v1/activity_logs/test_create_activity_log.py
@@ -1,0 +1,68 @@
+import sys, os
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from main import app
+from api.v1.models.activity_logs import ActivityLog
+from api.v1.services.activity_logs import activity_log_service
+from api.db.database import get_db
+from fastapi import status
+
+client = TestClient(app)
+CREATE_ACTIVITY_LOG_ENDPOINT = '/api/v1/activity-logs/create'
+
+@pytest.fixture
+def mock_db_session():
+    """Fixture to create a mock database session."""
+    with patch("api.v1.services.user.get_db", autospec=True) as mock_get_db:
+        mock_db = MagicMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        yield mock_db
+    app.dependency_overrides = {}
+
+@pytest.fixture
+def mock_activity_log_service():
+    """Fixture to create a mock activity log service."""
+    with patch("api.v1.services.activity_logs.activity_log_service", autospec=True) as mock_service:
+        yield mock_service
+
+def create_mock_activity_log(mock_db_session, user_id: int, action: str):
+    """Create a mock activity log in the mock database session."""
+    mock_activity_log = ActivityLog(
+        id=1,
+        user_id=user_id,
+        action=action,
+        timestamp="2023-01-01T00:00:00"
+    )
+    mock_db_session.query.return_value.filter.return_value.first.return_value = mock_activity_log
+    return mock_activity_log
+
+@pytest.mark.usefixtures("mock_db_session", "mock_activity_log_service")
+def test_create_activity_log(mock_activity_log_service, mock_db_session):
+    """Test for creating an activity log."""
+    mock_user_id = 1
+    mock_action = "test_action"
+    
+    mock_activity_log = create_mock_activity_log(mock_db_session, mock_user_id, mock_action)
+    mock_activity_log_service.create_activity_log.return_value = mock_activity_log
+    
+    response = client.post(
+        CREATE_ACTIVITY_LOG_ENDPOINT,
+        json={"user_id": mock_user_id, "action": mock_action}
+    )
+    
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {
+        "status_code": 201,
+        "message": "Activity log created successfully",
+        "success": True,
+        "data": {
+            "user_id": mock_activity_log.user_id,
+            "action": mock_activity_log.action,
+        }
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

​Created a Create Activity Log route

## Related Issue
#494 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

​This was a feature required to create activity log for users

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

​I wrote tests for this route
I tested with postman

## Screenshots (if appropriate - Postman, etc):

​
![Screenshot (438)](https://github.com/user-attachments/assets/621fa7a1-9810-4ecd-94e4-085bf1269b81)

![Screenshot (439)](https://github.com/user-attachments/assets/186c0669-091f-4e29-a0af-a9fc6eed5c81)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
