### PR TITLE
feat: get newsletter subscribers

### DIFF
--- a/api/v1/routes/newsletter.py
+++ b/api/v1/routes/newsletter.py
@@ -5,12 +5,15 @@ from fastapi import (
     )
 from sqlalchemy.orm import Session
 from api.utils.success_response import success_response
-from api.v1.schemas.newsletter import EmailSchema
+from api.v1.schemas.newsletter import EmailSchema, EmailRetrieveSchema
 from api.db.database import get_db
 from api.v1.services.newsletter import NewsletterService
+from fastapi.encoders import jsonable_encoder
+from api.v1.models.user import User
+from api.v1.services.user import user_service
+from api.v1.services.newsletter import NewsletterService
 
-
-newsletter = APIRouter(tags=['Newsletter'])
+newsletter = APIRouter(prefix='/pages', tags=['Newsletter'])
 
 @newsletter.post('/newsletters')
 async def sub_newsletter(request: EmailSchema, db: Session = Depends(get_db)):
@@ -28,3 +31,25 @@ async def sub_newsletter(request: EmailSchema, db: Session = Depends(get_db)):
         message="Thank you for subscribing to our newsletter.",
         status_code=status.HTTP_201_CREATED
     )
+
+@newsletter.get('', response_model=success_response, 
+                 status_code=200,
+                 )
+def retrieve_contact_us(db: Session = Depends(get_db),
+                              admin: User = Depends(user_service.get_current_super_admin)):
+    """
+    Retrieve all newsletter subscription from database
+    """
+
+    subscriptions = NewsletterService.fetch_all(db)
+    subs_filtered = list(map(lambda x: EmailRetrieveSchema.model_validate(x),
+                                    subscriptions))
+    
+    if (len(subs_filtered) == 0):
+        subs_filtered = [{}]
+
+    return success_response(
+        message = "Subscriptions retrieved successfully",
+        status_code = 200,
+        data = jsonable_encoder(subs_filtered)
+        )

--- a/api/v1/routes/newsletter.py
+++ b/api/v1/routes/newsletter.py
@@ -32,10 +32,10 @@ async def sub_newsletter(request: EmailSchema, db: Session = Depends(get_db)):
         status_code=status.HTTP_201_CREATED
     )
 
-@newsletter.get('', response_model=success_response, 
+@newsletter.get('/newsletters', response_model=success_response, 
                  status_code=200,
                  )
-def retrieve_contact_us(db: Session = Depends(get_db),
+def retrieve_subscribers(db: Session = Depends(get_db),
                               admin: User = Depends(user_service.get_current_super_admin)):
     """
     Retrieve all newsletter subscription from database

--- a/api/v1/schemas/newsletter.py
+++ b/api/v1/schemas/newsletter.py
@@ -8,3 +8,8 @@ class EmailSchema(BaseModel):
 
     email: EmailStr
     
+
+class EmailRetrieveSchema(EmailSchema):
+
+    class Config:
+        from_attributes = True

--- a/api/v1/services/newsletter.py
+++ b/api/v1/services/newsletter.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from api.v1.schemas.newsletter import EmailSchema
 from api.core.base.services import Service
 from api.v1.models.newsletter import Newsletter
-
+from typing import Optional, Any
 
 class NewsletterService(Service):
     '''Newsletter service functionality'''
@@ -33,3 +33,17 @@ class NewsletterService(Service):
             raise HTTPException(status_code=400, detail='User already subscribed to newsletter')
 
         return newsletter
+    
+    @staticmethod
+    def fetch_all(self, db: Session, **query_params: Optional[Any]):
+        '''Fetch all submisions with option to search using query parameters'''
+
+        query = db.query(Newsletter)
+
+        # Enable filter by query parameter
+        if query_params:
+            for column, value in query_params.items():
+                if hasattr(Newsletter, column) and value:
+                    query = query.filter(getattr(Newsletter, column).ilike(f'%{value}%'))
+
+        return query.all()

--- a/api/v1/services/newsletter.py
+++ b/api/v1/services/newsletter.py
@@ -35,8 +35,8 @@ class NewsletterService(Service):
         return newsletter
     
     @staticmethod
-    def fetch_all(self, db: Session, **query_params: Optional[Any]):
-        '''Fetch all submisions with option to search using query parameters'''
+    def fetch_all(db: Session, **query_params: Optional[Any]):
+        '''Fetch all newsletter subscriptions with option to search using query parameters'''
 
         query = db.query(Newsletter)
 

--- a/api/v1/services/newsletter.py
+++ b/api/v1/services/newsletter.py
@@ -2,19 +2,17 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 from api.v1.schemas.newsletter import EmailSchema
 from api.core.base.services import Service
-from api.v1.models.newsletter import Newsletter
+from api.v1.models.newsletter import NewsletterSubscriber
 from typing import Optional, Any
 
 class NewsletterService(Service):
     '''Newsletter service functionality'''
 
     @staticmethod
-    def create(db: Session, request: EmailSchema) -> Newsletter:
+    def create(db: Session, request: EmailSchema) -> NewsletterSubscriber:
         '''add a new subscriber'''
 
-        new_subscriber = Newsletter(
-            title="",
-            content="",
+        new_subscriber = NewsletterSubscriber(
             email=request.email)
         db.add(new_subscriber)
         db.commit()
@@ -23,12 +21,12 @@ class NewsletterService(Service):
         return new_subscriber
 
     @staticmethod
-    def check_existing_subscriber(db: Session, request: EmailSchema) -> Newsletter:
+    def check_existing_subscriber(db: Session, request: EmailSchema) -> NewsletterSubscriber:
         """
         Check if user with email already exist
         """
 
-        newsletter = db.query(Newsletter).filter(Newsletter.email==request.email).first()
+        newsletter = db.query(NewsletterSubscriber).filter(NewsletterSubscriber.email==request.email).first()
         if newsletter:
             raise HTTPException(status_code=400, detail='User already subscribed to newsletter')
 
@@ -38,12 +36,12 @@ class NewsletterService(Service):
     def fetch_all(db: Session, **query_params: Optional[Any]):
         '''Fetch all newsletter subscriptions with option to search using query parameters'''
 
-        query = db.query(Newsletter)
+        query = db.query(NewsletterSubscriber)
 
         # Enable filter by query parameter
         if query_params:
             for column, value in query_params.items():
-                if hasattr(Newsletter, column) and value:
-                    query = query.filter(getattr(Newsletter, column).ilike(f'%{value}%'))
+                if hasattr(NewsletterSubscriber, column) and value:
+                    query = query.filter(getattr(NewsletterSubscriber, column).ilike(f'%{value}%'))
 
         return query.all()

--- a/tests/v1/newsletter/newsletter_test.py
+++ b/tests/v1/newsletter/newsletter_test.py
@@ -6,11 +6,19 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')
 
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock
 from main import app
 from api.db.database import get_db
 from api.v1.models.newsletter import Newsletter
 from api.v1.schemas.newsletter import EmailSchema
+from unittest.mock import patch, MagicMock
+from api.v1.services.newsletter import NewsletterService
+from api.v1.services.user import oauth2_scheme, user_service
+
+def mock_deps():
+    return MagicMock(id="user_id")
+
+def mock_oauth():
+    return 'access_token'
 
 client = TestClient(app)
 
@@ -40,7 +48,7 @@ def test_sub_newsletter_success(db_session_mock):
     email_data = {"email": "test1@example.com"}
 
     # Act
-    response = client.post("/api/v1/newsletters", json=email_data)
+    response = client.post("/api/v1/pages/newsletters", json=email_data)
 
     # Assert
     assert response.status_code == 201
@@ -54,10 +62,76 @@ def test_sub_newsletter_existing_email(db_session_mock):
     email_data = {"email": "test@example.com"}
 
     # Act
-    response = client.post("/api/v1/newsletters", json=email_data)
+    response = client.post("/api/v1/pages/newsletters", json=email_data)
 
     # Assert
     assert response.status_code == 400
+
+class TestCodeUnderTest:
+
+    @classmethod 
+    def setup_class(cls):
+        app.dependency_overrides[user_service.get_current_super_admin] = mock_deps
+
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Successfully retrieves all subscriptions from db
+    def test_retrieve_subscription_success(self, client, mocker):
+        mock_subs= [{"email": "test@example.com",
+                             "title": "Dr", "content": ""},
+                            {"email": "test1@example.com",
+                             "title": "Mr", "content": ""}]
+
+        mocker.patch.object(NewsletterService, 'fetch_all', return_value=mock_subs)
+
+        response = client.get('/api/v1/pages/newsletters')
+
+        assert response.status_code == 200
+        assert response.json()['success'] == True
+        assert response.json()['message'] == "Subscriptions retrieved successfully"
+        assert len(response.json()['data']) == len(mock_subs)
+
+    # No subscriptions in database
+    def test_retrieve_contact_us_no_submissions(self, client, mocker):
+        mock_submissions = [{}]
+
+        mocker.patch.object(NewsletterService, 'fetch_all', return_value=mock_submissions)
+
+        response = client.get('/api/v1/pages/newsletters')
+
+        assert response.status_code == 200
+        assert response.json()['success'] == True
+        assert response.json()['message'] == "Subscriptions retrieved successfully"
+
+
+    # # Unauthorized access to the endpoint    
+    def test_retrieve_unauthorized(self, client):
+        app.dependency_overrides = {}
+        app.dependency_overrides[oauth2_scheme] = mock_oauth
+
+        with patch('api.v1.services.user.user_service.get_current_user', return_value=MagicMock(is_super_admin=False)) as cu:
+
+            response = client.get('/api/v1/pages/newsletters')
+
+            assert response.status_code == 403
+            assert response.json()['success'] == False
+            assert response.json()['message'] == 'You do not have permission to access this resource'
+
+    # # Unauthenticated access to the endpoint    
+    def test_retrieve_contact_unauthenticated(self, client):
+        app.dependency_overrides = {}
+
+        response = client.get('/api/v1/pages/newsletters')
+
+        assert response.status_code == 401
+        assert response.json()['success'] == False
+        assert response.json()['message'] == 'Not authenticated'
+
+
+
 
 
 if __name__ == "__main__":

--- a/tests/v1/newsletter/newsletter_test.py
+++ b/tests/v1/newsletter/newsletter_test.py
@@ -79,7 +79,7 @@ class TestCodeUnderTest:
         app.dependency_overrides = {}
 
     # Successfully retrieves all subscriptions from db
-    def test_retrieve_subscription_success(self, client, mocker):
+    def test_retrieve_subscription_success(self, mocker):
         mock_subs= [{"email": "test@example.com",
                              "title": "Dr", "content": ""},
                             {"email": "test1@example.com",
@@ -95,8 +95,9 @@ class TestCodeUnderTest:
         assert len(response.json()['data']) == len(mock_subs)
 
     # No subscriptions in database
-    def test_retrieve_contact_us_no_submissions(self, client, mocker):
-        mock_submissions = [{}]
+    def test_retrieve_contact_us_no_submissions(self, mocker):
+        mock_submissions = []
+        app.dependency_overrides[user_service.get_current_super_admin] = mock_deps
 
         mocker.patch.object(NewsletterService, 'fetch_all', return_value=mock_submissions)
 
@@ -105,10 +106,11 @@ class TestCodeUnderTest:
         assert response.status_code == 200
         assert response.json()['success'] == True
         assert response.json()['message'] == "Subscriptions retrieved successfully"
+        assert response.json()['data'] == [{}]
 
 
     # # Unauthorized access to the endpoint    
-    def test_retrieve_unauthorized(self, client):
+    def test_retrieve_unauthorized(self):
         app.dependency_overrides = {}
         app.dependency_overrides[oauth2_scheme] = mock_oauth
 
@@ -121,7 +123,7 @@ class TestCodeUnderTest:
             assert response.json()['message'] == 'You do not have permission to access this resource'
 
     # # Unauthenticated access to the endpoint    
-    def test_retrieve_contact_unauthenticated(self, client):
+    def test_retrieve_contact_unauthenticated(self):
         app.dependency_overrides = {}
 
         response = client.get('/api/v1/pages/newsletters')

--- a/tests/v1/newsletter/newsletter_test.py
+++ b/tests/v1/newsletter/newsletter_test.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from main import app
 from api.db.database import get_db
-from api.v1.models.newsletter import Newsletter
+from api.v1.models.newsletter import NewsletterSubscriber
 from api.v1.schemas.newsletter import EmailSchema
 from unittest.mock import patch, MagicMock
 from api.v1.services.newsletter import NewsletterService
@@ -41,7 +41,7 @@ def override_get_db(db_session_mock):
 
 def test_sub_newsletter_success(db_session_mock):
     # Arrange
-    db_session_mock.query(Newsletter).filter().first.return_value = None
+    db_session_mock.query(NewsletterSubscriber).filter().first.return_value = None
     db_session_mock.add.return_value = None
     db_session_mock.commit.return_value = None
 
@@ -56,8 +56,8 @@ def test_sub_newsletter_success(db_session_mock):
 
 def test_sub_newsletter_existing_email(db_session_mock):
     # Arrange
-    existing_subscriber = Newsletter(email="test@example.com")
-    db_session_mock.query(Newsletter).filter().first.return_value = existing_subscriber
+    existing_subscriber = NewsletterSubscriber(email="test@example.com")
+    db_session_mock.query(NewsletterSubscriber).filter().first.return_value = existing_subscriber
 
     email_data = {"email": "test@example.com"}
 
@@ -80,11 +80,8 @@ class TestCodeUnderTest:
 
     # Successfully retrieves all subscriptions from db
     def test_retrieve_subscription_success(self, mocker):
-        mock_subs= [{"email": "test@example.com",
-                             "title": "Dr", "content": ""},
-                            {"email": "test1@example.com",
-                             "title": "Mr", "content": ""}]
-
+        mock_subs= [{"email": "test@example.com"},
+                    {"email": "test1@example.com"}]
         mocker.patch.object(NewsletterService, 'fetch_all', return_value=mock_subs)
 
         response = client.get('/api/v1/pages/newsletters')

--- a/tests/v1/notification/test_get_user_nots.py
+++ b/tests/v1/notification/test_get_user_nots.py
@@ -42,7 +42,6 @@ access_token = user_service.create_access_token(str(user_id))
 
 user = User(
     id=user_id,
-    username="testuser1",
     email="testuser1@gmail.com",
     password=user_service.hash_password("Testpassword@123"),
     first_name="Test",


### PR DESCRIPTION
 ## Description
Create an API endpoint that allows an admin retrieve the emails​ of all newsletter subscribers

The changes include:
 
* **Endpoint Addition:** Added `GET /api/v1/pages/newsletters` for getting all newsletter subscribers
* **Error Handling:** Implemented checks for unauthorized access.
* **Testing:** Added `pytest` cases to ensure functionality and edge cases are covered.
 
 
## Related Issue (Link to issue ticket)
[Issue Ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/549)


 ## Motivation and Context
This feature is essential to enable administrators view the information about all newsletter subscribers.
 
 ## How Has This Been Tested?
 * **Unit Tests:**
    * Added tests to validate the retrieval of subscriptions from the database. 
    * Also tests to validate authorization and authentication failures.

* **Test Environment:** Tests were run using a mocked database instance to avoid interference with the production environment.

Tests include:
 
* Retrieving a subscriptions from the database successfully.
* Handling unauthorized access.

## Screenshots:
### Successful Request
![image](https://github.com/user-attachments/assets/d0ac3dcc-0e76-45c8-9775-b763c2d9a1a6)


### Unauthorized request
![image](https://github.com/user-attachments/assets/d76e5b6e-e947-4004-ada4-f966de80da43)


## Types of changes
* [x]  New feature (non-breaking change which adds functionality)
 
 ## Checklist:
 * [x]  My code follows the code style of this project.
 * [x]  My change requires a change to the documentation.
 * [x]  I have updated the documentation accordingly.
 * [x]  I have read the **CONTRIBUTING** document.
 * [x]  I have added tests to cover my changes.
 * [x]  All new and existing tests passed.