### PR TITLE
fix: Renamed billing plan creation route to the unified naming scheme

### DIFF
--- a/api/v1/routes/billing_plan.py
+++ b/api/v1/routes/billing_plan.py
@@ -12,7 +12,7 @@ from api.db.database import get_db
 from api.v1.services.user import user_service
 from api.v1.schemas.plans import CreateSubscriptionPlan
 
-bill_plan = APIRouter(prefix='/organizations', tags=['Billing-Plan'])
+bill_plan = APIRouter(prefix='/organizations', tags=['Pricing'])
 
 @bill_plan.get('/billing-plans', response_model=success_response)
 async def retrieve_all_billing_plans(
@@ -32,17 +32,18 @@ async def retrieve_all_billing_plans(
         }
     )
 
-@bill_plan.post('/billing-plans', response_model=success_response)
+@bill_plan.post('/{organization_id}/billing-plans', response_model=success_response)
 async def create_new_billing_plan(
+    organization_id: str,
     request: CreateSubscriptionPlan,
     current_user: User = Depends(user_service.get_current_super_admin),
     db: Session = Depends(get_db)
 ):
     """
-    Endpoint to create new billing plan 
+    Endpoint to create new billing plan by a super-admin
     """
 
-    plan = billing_plan_service.create(db=db, request=request)
+    plan = billing_plan_service.create(db=db, request=request, organization_id=organization_id)
 
     return success_response(
         status_code=status.HTTP_200_OK,

--- a/api/v1/schemas/plans.py
+++ b/api/v1/schemas/plans.py
@@ -7,7 +7,6 @@ class CreateSubscriptionPlan(BaseModel):
     price: int
     duration: str
     currency: str
-    organization_id: str
     features: List[str]
     
     

--- a/api/v1/services/billing_plan.py
+++ b/api/v1/services/billing_plan.py
@@ -3,17 +3,22 @@ from api.v1.models.billing_plan import BillingPlan
 from typing import Any, Optional
 from api.core.base.services import Service
 from api.v1.schemas.plans import CreateSubscriptionPlan
+from api.utils.db_validators import check_model_existence
+from api.v1.models.organization import Organization
 
 
 class BillingPlanService(Service):
 	'''Product service functionality'''
 
-	def create(db: Session, request: CreateSubscriptionPlan):
+	def create(db: Session, request: CreateSubscriptionPlan, organization_id: str):
 		"""
 		Create and return a new billing plan
 		"""
 
-		plan = BillingPlan(**request.dict())
+		# check the a valid organization id is passed
+		check_model_existence(db, Organization, organization_id)
+
+		plan = BillingPlan(**request.dict(), organization_id=organization_id)
 		db.add(plan)
 		db.commit()
 		db.refresh(plan)

--- a/tests/v1/billing_plan/test_billing_plan.py
+++ b/tests/v1/billing_plan/test_billing_plan.py
@@ -69,11 +69,12 @@ def test_fetch_all_plans(mock_user_service, mock_db_session):
 @pytest.mark.usefixtures("mock_db_session", "mock_user_service")
 def test_create_new_plans(mock_user_service, mock_db_session):
     """Billing plan creation test."""
+
+    url = '/api/v1/organizations/s2334d/billing-plans'
     mock_user = create_mock_user(mock_user_service, mock_db_session)
     access_token = user_service.create_access_token(user_id=str(uuid7()))
     data = {
             "name": "Advanced",
-            "organization_id": "s2334d",
             "description": "All you need in one pack",
             "price": 80,
             "duration": "Monthly",
@@ -85,7 +86,7 @@ def test_create_new_plans(mock_user_service, mock_db_session):
             }
     
     response = client.post(
-        BILLPLAN_ENDPOINT,
+        url,
         headers={'Authorization': f'Bearer {access_token}'},
         json=data
         )


### PR DESCRIPTION
This PR simply renamed the endpoint to follow the unified backend endpoint scheme. The actual implementation have already been merged. 

## Changes made
**FROM**  **`POST /api/v1/organizations/billing-plans`** **TO** **`POST /api/v1/organizations/{organization_id}/billing-plans`**

## Description
Develop an endpoint to create new billing plans. The endpoint will handle requests to create a new plan with the specified details. If the plan is created successfully, a confirmation message will be returned to the client with a '201 Created' status. If an error occurs during creation, an appropriate error status will be returned.

## Related Issue (Link to issue ticket)
[Link to issue ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/242)

## How Has This Been Tested?
This implementation has been thoroughly tested with Postman and has the following test coverage
- Created a new billing plan using Postman to ensure the endpoint works as expected.
- Verified that the new billing plan is correctly stored in the database.
- Checked that the endpoint returns the appropriate success message and status code.
- Ensured that all existing endpoints and tests continued to function correctly after adding the new endpoint.
​
## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/c70384a5-fe9e-4be5-be3e-037f3fbe02fb)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
