### PR TITLE
fix: fixed create testimonial endpoint test

### DIFF
--- a/tests/v1/testimonial/test_create_testimonial.py
+++ b/tests/v1/testimonial/test_create_testimonial.py
@@ -36,7 +36,6 @@ def before_all(client: client, session: session) -> pytest.fixture:
     user = client.post(
         "/api/v1/auth/register",
         json={
-            "username": "testuser1",
             "password": "strin8Hsg263@",
             "first_name": "string",
             "last_name": "string",
@@ -50,7 +49,7 @@ def before_all(client: client, session: session) -> pytest.fixture:
 def test_create_testimonial(client: client, session: session) -> pytest:
     status_code = payload[0].pop("status_code")
     res = client.post(
-        "api/v1/testimonials",
+        "api/v1/testimonials/",
         json=payload[0],
         headers={"Authorization": f"Bearer {auth_token}"},
     )
@@ -64,7 +63,7 @@ def test_create_testimonial(client: client, session: session) -> pytest:
 def test_create_testimonial_unauthorized(client: client, session: session) -> pytest:
     status_code = 401
     res = client.post(
-        "api/v1/testimonials",
+        "api/v1/testimonials/",
         json=payload[1],
     )
 
@@ -73,7 +72,7 @@ def test_create_testimonial_unauthorized(client: client, session: session) -> py
 def test_create_testimonial_missing_content(client: client, session: session) -> pytest:
     status_code = payload[2].pop("status_code")
     res = client.post(
-        "api/v1/testimonials",
+        "api/v1/testimonials/",
         json=payload[2],
         headers={"Authorization": f"Bearer {auth_token}"},
     )
@@ -83,7 +82,7 @@ def test_create_testimonial_missing_content(client: client, session: session) ->
 def test_create_testimonial_missing_ratings(client: client, session: session) -> pytest:
     status_code = payload[3].pop("status_code")
     res = client.post(
-        "api/v1/testimonials",
+        "api/v1/testimonials/",
         json=payload[3],
         headers={"Authorization": f"Bearer {auth_token}"},
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixed the endpoint route of the test file
​

## Description

<!--- Describe your changes in detail -->
The tests are failing because the route at the test files is not correct. it's pointing to the root url of the testimonials rather than the sub url of creating testimonials
​

## Related Issue (Link to issue ticket)
- #79 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The tests are core part of development and ensuring each test passing is important thing to continue the development
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with pytest.
​

## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/cbf40d14-7dd0-4c0b-8af7-fd77f394e08d)

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
