### PR TITLE
bug fix : fixed bug in pagination for get all testimonials endpoint

### DIFF
--- a/api/v1/routes/testimonial.py
+++ b/api/v1/routes/testimonial.py
@@ -6,7 +6,7 @@ from fastapi.encoders import jsonable_encoder
 from api.db.database import get_db
 from sqlalchemy.orm import Session
 from api.v1.models.user import User
-from fastapi import Depends, APIRouter, status
+from fastapi import Depends, APIRouter, status,Query
 from api.utils.success_response import success_response
 from api.v1.services.testimonial import testimonial_service
 from api.v1.services.user import user_service
@@ -21,8 +21,8 @@ testimonial = APIRouter(prefix="/testimonials", tags=['Testimonial'])
 
 @testimonial.get("", status_code=status.HTTP_200_OK)
 def get_testimonials(
-    page_size: int = 10 ,
-    page: int =0 ,
+    page_size: Annotated[int, Query(ge=1, description="Number of products per page")] = 10,
+    page: Annotated[int, Query(ge=1, description="Page number (starts from 1)")] = 0,
     db: Session = Depends(get_db),
 ):
     """End point to Query Testimonials with pagination"""


### PR DESCRIPTION
## Description

Fixed a bug that makes the get all testimonial endpoint return 500 instead of 422 on validation errors


​

## Motivation and Context

While testing the  get all testimonial i noticed the endpoint returned 500 instead of 422 on validation errors

## Screenshots (if appropriate - Postman, etc):
Before
​![Screenshot 2024-07-31 211437](https://github.com/user-attachments/assets/a7aa975b-4fa6-42fb-87ae-0b390eca63e6)
After
![Screenshot 2024-07-31 211503](https://github.com/user-attachments/assets/1303fc29-48b4-439a-b574-4d9cb70b4e9e)

## Types of changes
A  bug fix change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
