### PR TITLE
feat: fetch squeeze pages

### DIFF
--- a/api/v1/routes/squeeze.py
+++ b/api/v1/routes/squeeze.py
@@ -4,7 +4,7 @@ from api.db.database import get_db
 from api.core.responses import SUCCESS
 from api.utils.success_response import success_response
 from api.v1.services.squeeze import squeeze_service
-from api.v1.schemas.squeeze import CreateSqueeze
+from api.v1.schemas.squeeze import CreateSqueeze, FilterSqueeze
 from api.v1.services.user import user_service
 from api.v1.models import *
 
@@ -25,3 +25,28 @@ def create_squeeze(
     data.full_name = f"{user.first_name} {user.last_name}"
     new_squeeze = squeeze_service.create(db, data)
     return success_response(status.HTTP_201_CREATED, SUCCESS, new_squeeze.to_dict())
+
+
+@squeeze.get("", response_model=success_response, status_code=200)
+def get_all_squeeze(
+    filter: FilterSqueeze = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_super_admin),
+):
+    """Get all squeeze pages"""
+    squeeze_pages = squeeze_service.fetch_all(db, filter)
+    return success_response(status.HTTP_200_OK, SUCCESS, squeeze_pages)
+
+
+@squeeze.get("/{squeeze_id}", response_model=success_response, status_code=200)
+def get_squeeze(
+    squeeze_id: str,
+    filter: FilterSqueeze = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_super_admin),
+):
+    """Get a squeeze page"""
+    squeeze_page = squeeze_service.fetch(db, squeeze_id, filter)
+    if not squeeze_page:
+        return success_response(status.HTTP_404_NOT_FOUND, "Squeeze page not found!")
+    return success_response(status.HTTP_200_OK, SUCCESS, squeeze_page)

--- a/api/v1/schemas/squeeze.py
+++ b/api/v1/schemas/squeeze.py
@@ -17,3 +17,7 @@ class CreateSqueeze(BaseModel):
     type: str = "product"
     status: SqueezeStatusEnum = SqueezeStatusEnum.offline
     full_name: str = None
+
+
+class FilterSqueeze(BaseModel):
+    status: SqueezeStatusEnum = None

--- a/api/v1/services/squeeze.py
+++ b/api/v1/services/squeeze.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 from api.core.base.services import Service
 from api.v1.models.squeeze import Squeeze
-from api.v1.schemas.squeeze import CreateSqueeze
+from api.v1.schemas.squeeze import CreateSqueeze, FilterSqueeze
 
 
 class SqueezeService(Service):
@@ -26,13 +26,27 @@ class SqueezeService(Service):
         db.refresh(new_squeeze)
         return new_squeeze
 
-    def fetch_all(self, db: Session):
+    def fetch_all(self, db: Session, filter: FilterSqueeze = None):
         """Fetch all squeeze pages"""
-        pass
+        squeezes = []
+        if filter:
+            squeezes = db.query(Squeeze).filter(Squeeze.status == filter.status).all()
+        else:
+            squeezes = db.query(Squeeze).all()
+        return squeezes
 
-    def fetch(self, db: Session, id: str):
+    def fetch(self, db: Session, id: str, filter: FilterSqueeze = None):
         """Fetch a specific squeeze page"""
-        pass
+        squeeze = None
+        if filter:
+            squeeze = (
+                db.query(Squeeze)
+                .filter(Squeeze.id == id, Squeeze.status == filter.status)
+                .first()
+            )
+        else:
+            squeeze = db.query(Squeeze).filter(Squeeze.id == id).first()
+        return squeeze
 
     def update(self, db: Session, id: str, schema):
         """Update a specific squeeze page"""

--- a/tests/v1/squeeze_page/test_fetch_squeeze.py
+++ b/tests/v1/squeeze_page/test_fetch_squeeze.py
@@ -1,0 +1,89 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from api.db.database import get_db
+from unittest.mock import MagicMock, patch
+from api.v1.models import *
+from api.v1.services.user import user_service
+from uuid_extensions import uuid7
+from fastapi import status
+from api.db.database import get_db
+
+client = TestClient(app)
+URI = "/api/v1/squeeze"
+LOGIN_URI = "api/v1/auth/login"
+
+squeeze1 = {
+    "id": str(uuid7()),
+    "title": "My Squeeze Page",
+    "email": "user1@example.com",
+    "headline": "My Headline 1",
+    "sub_headline": "My Sub Headline 1",
+    "body": "My Body 1",
+    "type": "product",
+    "status": "offline",
+    "user_id": str(uuid7()),
+    "full_name": "My Full Name 1",
+}
+squeeze2 = {
+    "title": "My Squeeze Page",
+    "email": "user1@example.com",
+    "headline": "My Headline 2",
+    "sub_headline": "My Sub Headline 2",
+    "type": "product",
+    "status": "online",
+    "user_id": str(uuid7()),
+    # expected response
+    "status_code": 201,
+}
+
+@pytest.fixture
+def mock_db_session(_=MagicMock()):
+    """Mock session"""
+    with patch(get_db.__module__):
+        app.dependency_overrides[get_db] = lambda: _
+        yield _
+    app.dependency_overrides = {}
+
+
+def create_mock_super_admin(_):
+    """Mock super admin"""
+    _.query.return_value.filter.return_value.first.return_value = User(
+        id=str(uuid7()),
+        email="user1@example.com",
+        password=user_service.hash_password("P@ssw0rd"),
+        is_super_admin=True,
+    )
+
+
+theader = lambda _: {"Authorization": f"Bearer {_}"}
+
+
+@pytest.mark.parametrize("data", [squeeze1])
+@pytest.mark.usefixtures("mock_db_session")
+def test_fetch_squeeze_page(mock_db_session, data):
+    """Test create squeeze page."""
+    create_mock_super_admin(mock_db_session)
+    tok = client.post(
+        LOGIN_URI, json={"email": "user1@example.com", "password": "P@ssw0rd"}
+    ).json()
+    assert tok["status_code"] == status.HTTP_200_OK
+    token = tok["data"]["user"]["access_token"]
+    res = client.post(URI, json=data, headers=theader(token))
+    id = res.json()["data"]["id"]
+    response = client.get(f"{URI}/{id}", headers=theader(token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.parametrize("data", [squeeze1, squeeze2])
+@pytest.mark.usefixtures("mock_db_session")
+def test_fetch_all_squeeze_page(mock_db_session, data):
+    """Test create squeeze page."""
+    create_mock_super_admin(mock_db_session)
+    tok = client.post(
+        LOGIN_URI, json={"email": "user1@example.com", "password": "P@ssw0rd"}
+    ).json()
+    assert tok["status_code"] == status.HTTP_200_OK
+    token = tok["data"]["user"]["access_token"]
+    response = client.get(URI, headers=theader(token))
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've added the `GET /api/v1/squeeze/:id` and `GET /api/v1/squeeze` endpoints to retrieve squeeze pages. There is also an optional filter to sort the squeeze pages by state.
​

## Description

<!--- Describe your changes in detail -->
implemented a new endpoint to enhance the functionality of our platform. This addition is specifically designed to facilitate the retrieval of squeeze pages, which are essential for marketing campaigns and lead generation efforts. The integration of this feature marks a significant improvement in our service offerings, allowing users to efficiently access and manage their squeeze pages within our system.
​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #643 
​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fetching squeeze pages is essential for rendering them on the frontend.​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
pytest
```
​

## Screenshots (if appropriate - Postman, etc):
- fetch all squeeze pages (without filter)
![image](https://github.com/user-attachments/assets/755b9db3-e5f6-403f-8d3d-f8de67c41b84)
- fetch squeeze page by id
![image](https://github.com/user-attachments/assets/0a1c167e-2fb3-4586-93bb-8085f3873af0)
- fetch squeeze pages (filtered by online status)
![image](https://github.com/user-attachments/assets/d6804569-99d3-4022-9875-685c0f0dc6f2)
- fetch squeeze pages (filtered by offline status)
![image](https://github.com/user-attachments/assets/0e815124-28cb-4eb2-a2e1-f364b5e5dff4)

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
