### PR TITLE
feat:fetch user activity logs

### DIFF
--- a/api/v1/routes/activity_logs.py
+++ b/api/v1/routes/activity_logs.py
@@ -30,14 +30,44 @@ async def create_activity_log(
     )
 
 
-@activity_logs.get("/", response_model=list[ActivityLogResponse])
+@activity_logs.get("", response_model=list[ActivityLogResponse])
 async def get_all_activity_logs(current_user: User = Depends(user_service.get_current_super_admin), db: Session = Depends(get_db)):
     '''Get all activity logs'''
 
-    activity_logs = activity_log_service.get_all_activity_logs(db=db)
+    activity_logs = activity_log_service.fetch_all(db=db)
 
     return success_response(
         status_code=200,
         message="Activity logs retrieved successfully",
+        data=jsonable_encoder(activity_logs)
+    )
+
+@activity_logs.get("/{user_id}", status_code=status.HTTP_200_OK)
+async def fetch_all_users_activity_log(
+    user_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_super_admin)
+):
+    """
+    Get endpoint for admin users get a users activity logs.
+
+    Args:
+        user_id (str): the id of user
+        current_user: the admin user
+        db: the database session object
+
+    Returns:
+        Response: a response object containing details if successful or appropriate errors if not
+    """
+
+
+    activity_logs = activity_log_service.fetch_all(
+        db=db,
+        user_id=user_id
+    )
+
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Activity logs fetched successfully!",
         data=jsonable_encoder(activity_logs)
     )

--- a/api/v1/services/activity_logs.py
+++ b/api/v1/services/activity_logs.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 from api.v1.models.activity_logs import ActivityLog
-from typing import Optional, List
+from typing import Optional, Any
 
 
 
@@ -16,10 +16,20 @@ class ActivityLogService:
         db.refresh(activity_log)
         return activity_log
 
-    def get_all_activity_logs(self, db: Session):
-        '''Retrieve all activity logs'''
+    def fetch_all(self, db: Session, **query_params: Optional[Any]):
+        """Fetch all products with option tto search using query parameters"""
 
-        return db.query(ActivityLog).all()
+        query = db.query(ActivityLog)
+
+        # Enable filter by query parameter
+        if query_params:
+            for column, value in query_params.items():
+                if hasattr(ActivityLog, column) and value:
+                    query = query.filter(
+                        getattr(ActivityLog, column).ilike(f"%{value}%")
+                    )
+        
+        return query.all()
 
 
 activity_log_service = ActivityLogService()

--- a/api/v1/services/billing_plan.py
+++ b/api/v1/services/billing_plan.py
@@ -8,7 +8,7 @@ from api.v1.schemas.plans import CreateSubscriptionPlan
 class BillingPlanService(Service):
     """Product service functionality"""
 
-    def create(db: Session, request: CreateSubscriptionPlan):
+    def create(self, db: Session, request: CreateSubscriptionPlan):
         """
         Create and return a new billing plan
         """
@@ -29,7 +29,7 @@ class BillingPlanService(Service):
     def update():
         pass
 
-    def fetch_all(db: Session, **query_params: Optional[Any]):
+    def fetch_all(self, db: Session, **query_params: Optional[Any]):
         """Fetch all products with option tto search using query parameters"""
 
         query = db.query(BillingPlan)
@@ -45,4 +45,4 @@ class BillingPlanService(Service):
         return query.all()
 
 
-billing_plan_service = BillingPlanService
+billing_plan_service = BillingPlanService()

--- a/tests/v1/activity_logs/test_get_a_user_activity_logs.py
+++ b/tests/v1/activity_logs/test_get_a_user_activity_logs.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone, timedelta
 
 
 client = TestClient(app)
-ACTIVITY_LOGS_ENDPOINT = '/api/v1/activity-logs'
+ACTIVITY_LOGS_ENDPOINT = '/api/v1/activity-logs/066abb38-fe41-74c4-8000-40699b6b4139'
 
 
 @pytest.fixture


### PR DESCRIPTION

### Implement GET Endpoint for User Activity Logs

**​ Description**

This pull request implements a new GET endpoint `api/v1/activity-logs/{user_id}` for fetching all activity logs of a specified user. This endpoint is intended for use by admin users only. The response will provide a structured JSON response containing the user's activity logs, including details such as action type and timestamps.

The expected JSON response format is as follows:
```json
{
  "status": 200,
  "message": "Activity logs fetched successfully!",
  "data": {
    "user_id": "str",
    "id": "str",
    "updated_at": "str",
    "action": "str",
    "timestamp": "str",
    "created_at": "str"
  }
}
```

**​ Related Issue**
[Issue #655](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/655)


**​ Motivation and Context**


This change is required to enable admin users to monitor user activity effectively. By fetching activity logs, admins can better manage and respond to user actions on the platform, ensuring security and accountability.

**​ How Has This Been Tested?**

The endpoint was tested using Postman with the following setup:

    Set the request method to GET.
    Use the URL: api/v1/activity-logs/{user_id} with a valid user ID.
    Include headers:

        Content-Type: application/json
        Authorization: Bearer <token> (with a valid admin token).

Multiple scenarios were tested, including valid and invalid user IDs, to ensure the proper functioning of the endpoint.

**​ Screenshots**
![image](https://github.com/user-attachments/assets/b5f8cf03-0fce-4805-97e7-1850ebeac30e)

**​ Types of changes**


- [ ] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**​Checklist**

- [x] My code follows the code style of this project. 
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation as needed. 
- [x] I have read the CONTRIBUTING document. 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.