### PR TITLE
feat: Add language retrieval API endpoint

### DIFF
--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -33,6 +33,7 @@ from api.v1.routes.squeeze import squeeze
 from api.v1.routes.dashboard import dashboard
 from api.v1.routes.email_template import email_template
 from api.v1.routes.contact import contact
+from api.v1.routes.language import language
 
 
 
@@ -72,3 +73,4 @@ api_version_one.include_router(test_router)
 api_version_one.include_router(squeeze)
 api_version_one.include_router(contact)
 api_version_one.include_router(dashboard)
+api_version_one.include_router(language)

--- a/api/v1/routes/language.py
+++ b/api/v1/routes/language.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from api.db.database import get_db
+from api.v1.services.language import get_unique_languages
+
+language = APIRouter(prefix="/languages", tags=["Regions, Timezone and Language"])
+
+@language.get("/", response_model=dict)
+async def get_languages(db: Session = Depends(get_db)):
+    try:
+        languages = get_unique_languages(db)
+        return {"languages": languages}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/api/v1/services/language.py
+++ b/api/v1/services/language.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Session
+from api.v1.models.regions import Region
+
+def get_unique_languages(db: Session):
+    try:
+        result = db.query(Region.language).filter(Region.language.isnot(None)).distinct().all()
+        languages = [row[0] for row in result]
+        return languages
+    except Exception as e:
+        raise Exception(f"Error retrieving languages: {str(e)}")

--- a/tests/v1/language/test_language.py
+++ b/tests/v1/language/test_language.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.exc import SQLAlchemyError
+from api.v1.services.language import get_unique_languages
+from fastapi.testclient import TestClient
+from main import app 
+
+client = TestClient(app)
+
+def test_get_unique_languages_success():
+    mock_db = MagicMock()
+    mock_query = MagicMock()
+    mock_query.filter.return_value.distinct.return_value.all.return_value = [
+        ('English',),
+        ('Spanish',),
+        ('French',),
+        ('German',),
+        ('Chinese',)
+    ]
+    mock_db.query.return_value = mock_query
+
+    languages = get_unique_languages(mock_db)
+    assert languages == ['English', 'Spanish', 'French', 'German', 'Chinese']
+
+def test_get_unique_languages_error():
+    mock_db = MagicMock()
+    mock_db.query.side_effect = SQLAlchemyError("Database error")
+
+    with pytest.raises(Exception) as excinfo:
+        get_unique_languages(mock_db)
+    
+    assert "Error retrieving languages" in str(excinfo.value)
+
+


### PR DESCRIPTION
## Description

This update introduces a new backend API endpoint `/api/v1/languages` that returns a list of supported languages for the application. The endpoint accepts GET requests and returns a JSON response with a list of languages.

## Related Issue (Link to issue ticket)


Link to Issue [#671](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/671)

## Motivation and Context

This change is required to provide clients with an easy way to access the list of supported languages, which is crucial for applications that need to adapt their content to different languages. 

## How Has This Been Tested?

-   Verified that the endpoint `/api/v1/languages` returns a 200 status code with the correct list of supported languages.
-   Tested various scenarios, including valid GET requests and ensured proper handling of any errors.

## Screenshots :
![Screenshot from 2024-08-05 17-24-22](https://github.com/user-attachments/assets/571e3999-f7dd-4320-935b-d2d771adfec1)




## Types of changes


-  [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


-  [ ]  My code follows the code style of this project.
-   [ ]  My change requires a change to the documentation.
-   [ ]  I have updated the documentation accordingly.
-   [ ]  I have read the **CONTRIBUTING** document.
-  [ ]   I have added tests to cover my changes.
-  [ ]  All new and existing tests passed.