### PR TITLE
feat: Endpoint to delete a role by the super admin

### DIFF
--- a/api/v1/routes/permissions/roles.py
+++ b/api/v1/routes/permissions/roles.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Path, Query, HTTPException
 from sqlalchemy.orm import Session
 from api.v1.schemas.permissions.roles import RoleCreate, RoleResponse, RoleAssignRequest
 from api.v1.services.permissions.role_service import role_service
+from api.v1.schemas.permissions.roles import RoleDeleteResponse
 from api.db.database import get_db
 from uuid_extensions import uuid7
 from api.v1.models.user import User
@@ -26,3 +27,12 @@ def assign_role(
     current_user: User = Depends(user_service.get_current_user)
 ):
     return role_service.assign_role_to_user(db, org_id, user_id, request.role_id)
+
+
+@role_perm.delete("/roles/{role_id}", tags=["delete role"], response_model=RoleDeleteResponse)
+def delete_role(
+    role_id: str, 
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user)
+):
+    return role_service.delete_role(db, role_id)

--- a/api/v1/schemas/permissions/roles.py
+++ b/api/v1/schemas/permissions/roles.py
@@ -13,3 +13,11 @@ class RoleResponse(BaseModel):
 
 class RoleAssignRequest(BaseModel):
     role_id: str
+    
+    
+class RoleDeleteResponse(BaseModel):
+    id: str
+    message: str
+
+    class Config:
+        orm_mode = True

--- a/api/v1/services/permissions/role_service.py
+++ b/api/v1/services/permissions/role_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 from api.v1.models.permissions.role import Role
 from api.v1.models.permissions.user_org_role import user_organization_roles
+from api.v1.schemas.permissions.roles import RoleDeleteResponse
 from api.v1.schemas.role import RoleCreate
 from uuid_extensions import uuid7
 from fastapi import HTTPException
@@ -39,6 +40,15 @@ class RoleService:
         except Exception as e:
             db.rollback()
             raise HTTPException(status_code=500, detail="An unexpected error occurred: " + str(e))
-
+        
+    @staticmethod
+    def delete_role(db: Session, role_id: str) -> RoleDeleteResponse:
+        role = db.query(Role).filter(Role.id == role_id).first()
+        if not role:
+            raise HTTPException(status_code=404, detail="Role not found")
+        
+        db.delete(role)
+        db.commit()
+        return RoleDeleteResponse(id=role_id, message="Role successfully deleted")
 
 role_service = RoleService()

--- a/tests/v1/roles_permissions/roles_test.py
+++ b/tests/v1/roles_permissions/roles_test.py
@@ -6,8 +6,10 @@ from fastapi.testclient import TestClient
 from datetime import datetime, timezone
 from uuid_extensions import uuid7
 from api.v1.services.user import user_service
+from fastapi import HTTPException
 from sqlalchemy.exc import IntegrityError
 from api.v1.schemas.permissions.permissions import PermissionCreate
+from api.v1.schemas.permissions.roles import RoleDeleteResponse
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
@@ -16,6 +18,7 @@ from main import app
 from api.v1.models.user import User
 from api.v1.models.permissions.permissions import Permission
 from api.v1.models.permissions.role import Role
+from api.v1.services.permissions.role_service import role_service
 from api.v1.services.permissions.permison_service import permission_service
 from api.db.database import get_db
 
@@ -27,6 +30,7 @@ client = TestClient(app)
 def mock_db_session():
     with patch("api.db.database.get_db", autospec=True) as mock_get_db:
         mock_db = MagicMock()
+        mock_get_db.return_value = mock_db
         app.dependency_overrides[get_db] = lambda: mock_db
         yield mock_db
     app.dependency_overrides = {}
@@ -50,9 +54,8 @@ def create_mock_user(mock_db_session, user_id):
     mock_db_session.query(User).filter_by(id=user_id).first.return_value = mock_user
     return mock_user
 
-
 def create_mock_permissions(mock_db_session, name, permision_id):
-    mock_permission= Permission(
+    mock_permission = Permission(
         id=permision_id,
         name=name
     )
@@ -64,6 +67,13 @@ def create_mock_role(mock_db_session, role_name):
     mock_db_session.add(role)
     mock_db_session.commit()
 
+@pytest.fixture
+def access_token(mock_db_session):
+    user_email = "mike@example.com"
+    user_id = str(uuid7())
+    create_mock_user(mock_db_session, user_id)
+    access_token = user_service.create_access_token(user_email)
+    return access_token
 
 def test_create_role_success(mock_db_session):
     """Test the successful creation of a role."""
@@ -73,7 +83,7 @@ def test_create_role_success(mock_db_session):
 
     access_token = user_service.create_access_token(str(user_email))
     mock_db_session.execute.return_value.fetchall.return_value = []
-    
+
     role_name = "TestRole"
     role_data = {"name": role_name}
 
@@ -81,3 +91,55 @@ def test_create_role_success(mock_db_session):
     response = client.post("/api/v1/roles", json=role_data, headers={'Authorization': f'Bearer {access_token}'})
     assert response.status_code == 200
     assert response.json()["name"] == role_name
+    
+    
+    
+
+def test_delete_role_success(mock_db_session, access_token):
+    role_id = "test-role-id"
+    response_data = RoleDeleteResponse(id=role_id, message="Role successfully deleted")
+
+    # Mock the delete_role method
+    role_service.delete_role = MagicMock(return_value=response_data)
+
+    response = client.delete(f"/api/v1/roles/{role_id}", headers={'Authorization': f'Bearer {access_token}'})
+
+    assert response.status_code == 200
+    assert response.json() == {"id": role_id, "message": "Role successfully deleted"}
+    role_service.delete_role.assert_called_once_with(mock_db_session, role_id)
+    
+    
+    
+
+def test_delete_role_unexpected_error(mock_db_session, access_token):
+    role_id = "test-role-id"
+
+    # Mock the delete_role method to raise an unexpected exception
+    role_service.delete_role = MagicMock(side_effect=HTTPException(status_code=500, detail="An unexpected error occurred"))
+
+    response = client.delete(f"/api/v1/roles/{role_id}", headers={'Authorization': f'Bearer {access_token}'})
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "message": "An unexpected error occurred",
+        "status": False,
+        "status_code": 500
+    }
+    role_service.delete_role.assert_called_once_with(mock_db_session, role_id)
+
+
+def test_delete_role_not_found(mock_db_session, access_token):
+    role_id = "non-existent-role-id"
+
+    # Mock the delete_role method to raise an HTTPException
+    role_service.delete_role = MagicMock(side_effect=HTTPException(status_code=404, detail="Role not found"))
+
+    response = client.delete(f"/api/v1/roles/{role_id}", headers={'Authorization': f'Bearer {access_token}'})
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "message": "Role not found",
+        "status": False,
+        "status_code": 404
+    }
+    role_service.delete_role.assert_called_once_with(mock_db_session, role_id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description

<!--- Describe your changes in detail -->

​This endpoint allows the super admin to delete a role.

This update introduces a new endpoint for users to delete roles. The changes include:

Endpoint: DELETE `/api/v1/roles/{role_id}`
Security: Roles are managed securely and deleted efficiently.

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​[here #688](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/688)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

​The change assists the super admin in managing roles by providing the ability to delete them when necessary.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This endpoint was tested using Postman and pytest.

​

## Screenshots (if appropriate - Postman, etc):

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.