### PR TITLE
feat: added endpoint to update user permissions

### DIFF
--- a/api/v1/routes/permissions/permisions.py
+++ b/api/v1/routes/permissions/permisions.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Path, Query, HTTPException
 from sqlalchemy.orm import Session
 from fastapi import status
-from api.v1.schemas.permissions.permissions import PermissionCreate, PermissionResponse, PermissionAssignRequest
+from api.v1.schemas.permissions.permissions import PermissionCreate, PermissionResponse, PermissionAssignRequest, PermissionUpdate
 from api.v1.services.permissions.permison_service import permission_service
 from api.db.database import get_db
 from uuid_extensions import uuid7
@@ -30,3 +30,13 @@ def delete_permissions(
     current_user: User = Depends(user_service.get_current_super_admin)
     ):
     return permission_service.delete_permission(db , permission_id)
+
+
+@perm_role.put("/roles/{role_id}/permissions/{permission_id}", tags=["update permissions"])
+def update_permission_endpoint(
+    new_permission_id: PermissionUpdate,  # New Permission ID from path
+    permission_id: str = Path(..., description="The ID of the old permission"),  # Old Permission ID from path
+    role_id: str = Path(..., description="The ID of the role"),  # Role ID from path
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_super_admin)):  # Assuming only super admins can update permissions
+    return permission_service.update_permission_on_role(db, role_id, permission_id, new_permission_id.new_permission_id)

--- a/api/v1/schemas/permissions/permissions.py
+++ b/api/v1/schemas/permissions/permissions.py
@@ -14,3 +14,6 @@ class PermissionResponse(BaseModel):
 
 class PermissionAssignRequest(BaseModel):
     permission_id: str
+    
+class PermissionUpdate(BaseModel):
+    new_permission_id: str

--- a/tests/v1/roles_permissions/test_update_perms.py
+++ b/tests/v1/roles_permissions/test_update_perms.py
@@ -1,0 +1,125 @@
+from uuid_extensions import uuid7
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from api.db.database import get_db
+from api.v1.models.permissions.permissions import Permission
+from api.v1.models.permissions.role import Role
+from api.v1.models.user import User
+from api.v1.services.user import user_service
+from main import app
+
+# Helper functions to create mock data
+def mock_role():
+    return Role(
+        id=str(uuid7()),
+        name="Test Role",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+def mock_permission():
+    return Permission(
+        id=str(uuid7()),
+        name="Test Permission",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+def mock_superuser():
+    return User(
+        id=str(uuid7()),
+        email="superuser@example.com",
+        password="hashedpassword",
+        first_name="Super",
+        last_name="User",
+        is_active=True,
+        is_super_admin=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+@pytest.fixture
+def db_session_mock():
+    db_session = MagicMock(spec=Session)
+    return db_session
+
+@pytest.fixture
+def client(db_session_mock):
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides = {}
+
+def test_update_role_permission_success(client, db_session_mock):
+    """Test updating a role's permission successfully"""
+
+    role = mock_role()
+    old_permission = mock_permission()
+    new_permission = mock_permission()
+    superuser = mock_superuser()
+
+    # Mock the role, permissions, and superuser
+    db_session_mock.query(Role).filter_by(id=role.id).first.return_value = role
+    db_session_mock.query(Permission).filter_by(id=old_permission.id).first.return_value = old_permission
+    db_session_mock.query(Permission).filter_by(id=new_permission.id).first.return_value = new_permission
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: superuser
+
+    # Mock the update function
+    db_session_mock.commit.return_value = None
+
+    response = client.put(
+        f"/api/v1/roles/{role.id}/permissions/{old_permission.id}",
+        json={"new_permission_id": new_permission.id},
+        headers={'Authorization': 'Bearer token'}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Permission updated successfully"
+
+def test_update_role_permission_not_found(client, db_session_mock):
+    """Test updating a role's permission when the role or permissions are not found"""
+
+    role_id = str(uuid7())
+    old_permission_id = str(uuid7())
+    new_permission_id = str(uuid7())
+    superuser = mock_superuser()
+
+    # Simulate role or permissions not found
+    db_session_mock.query(Role).filter_by(id=role_id).first.return_value = None
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: superuser
+
+    response = client.put(
+        f"/api/v1/roles/{role_id}/permissions/{old_permission_id}",
+        json={"new_permission_id": new_permission_id},
+        headers={'Authorization': 'Bearer token'}
+    )
+
+    assert response.status_code == 404
+    assert response.json()["message"] == "Role not found."
+
+def test_update_role_permission_invalid_permission(client, db_session_mock):
+    """Test updating a role's permission with an invalid new permission ID"""
+
+    role = mock_role()
+    old_permission = mock_permission()
+    superuser = mock_superuser()
+    new_perission = mock_permission()
+
+    # Mock the role and old permission
+    db_session_mock.query(Role).filter_by(id=role.id).first.return_value = role
+    db_session_mock.query(Permission).filter_by(id=old_permission.id).first.return_value = old_permission
+
+    # Simulate new permission not found
+    db_session_mock.query(Permission).filter_by(id=new_perission.id).first.return_value = None
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: superuser
+
+    response = client.put(
+        f"/api/v1/roles/{role.id}/permissions/{old_permission.id}",
+        json={"new_permission_id": new_perission.id},
+        headers={'Authorization': 'Bearer token'}
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->


I created an endpoint that updates permissions on a role.
I added unit tests for the update permissions endpoint, including scenarios where the permission is not found, invalid, the user is not authorized, and a successful update.
​

## Related Issue ([Link to issue ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/735))

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR ensures that the update permissions functionality is thoroughly tested, handling various edge cases and verifying the correct behavior of the endpoint. It prevents potential bugs and ensures the robustness of the permissions update process.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been handled with pytest. The update permissions tests check for various edge cases and ensure the endpoint functions correctly.
​

## Screenshots (if appropriate - Postman, etc):
## WITHOUT PROPER AUTHORISATION
![without_authorization](https://github.com/user-attachments/assets/176593b8-54d5-4222-84c7-d87e7371e2a5)
​## WITHOUT VALID ROLE ID
![invalid_roe_id](https://github.com/user-attachments/assets/6437de1a-9642-4815-a410-6b54747934c6)
## UPDATED SUCCESSFULY
![updated successfully](https://github.com/user-attachments/assets/f4711932-adb9-45d8-85bd-f46b760c91ab)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
