### PR TITLE
feat: Add endpoint to create terms and conditions with tests

### DIFF
--- a/tests/v1/terms_and_conditions/test_create_terms_and_conditions.py
+++ b/tests/v1/terms_and_conditions/test_create_terms_and_conditions.py
@@ -1,0 +1,108 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import status, HTTPException
+from unittest.mock import Mock
+from sqlalchemy.orm import Session
+
+from main import app
+from api.db.database import get_db
+from api.v1.models.terms import TermsAndConditions
+from api.v1.schemas.terms_and_conditions import UpdateTermsAndConditions
+from api.v1.services.user import user_service
+
+@pytest.fixture
+def mock_db():
+    return Mock(spec=Session)
+
+
+@pytest.fixture
+def mock_current_user():
+    user = Mock()
+    user.is_super_admin = True
+    user.id = 1
+    return user
+
+@pytest.fixture
+def client(mock_db, mock_current_user):
+    def override_get_db():
+        return mock_db
+
+    def override_get_current_super_admin():
+        return mock_current_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[user_service.get_current_super_admin] = override_get_current_super_admin
+    
+    with TestClient(app) as client:
+        yield client
+    
+    app.dependency_overrides.clear()
+
+
+def test_create_terms_and_conditions_success(client, mock_db, mock_current_user):
+    # Prepare test data
+    test_data = {
+        "title": "Test Terms and Conditions",
+        "content": "This is a test content for terms and conditions."
+    }
+
+    # Mock database query
+    mock_db.query.return_value.first.return_value = None
+
+    # Send POST request
+    response = client.post("/api/v1/terms-and-conditions", json=test_data)
+
+    # Assert response
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["message"] == "Successfully created terms and conditions"
+    assert "data" in response.json()
+    assert response.json()["data"]["title"] == test_data["title"]
+    assert response.json()["data"]["content"] == test_data["content"]
+
+    # Verify mock calls
+    mock_db.add.assert_called_once()
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once()
+
+def test_create_terms_and_conditions_already_exists(client, mock_db, mock_current_user):
+    # Prepare test data
+    test_data = {
+        "title": "New Terms and Conditions",
+        "content": "This should not be created."
+    }
+
+    # Mock existing terms and conditions
+    mock_existing_tc = Mock(spec=TermsAndConditions)
+    mock_db.query.return_value.first.return_value = mock_existing_tc
+
+    # Send POST request
+    response = client.post("/api/v1/terms-and-conditions", json=test_data)
+
+    # Assert response
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["message"] == "Terms and conditions already exist. Use PATCH to update."
+
+    # Verify mock calls
+    mock_db.add.assert_not_called()
+    mock_db.commit.assert_not_called()
+    mock_db.refresh.assert_not_called()
+
+def test_create_terms_and_conditions_unauthorized(client, mock_db,):
+    # mock get_current_super_admin function
+    def mock_get_current_super_admin():
+        raise HTTPException(
+            status_code=403,
+            detail="You do not have permission to access this resource",
+        )
+
+    app.dependency_overrides[user_service.get_current_super_admin] = mock_get_current_super_admin
+
+    test_data = {
+        "title": "Test Terms and Conditions",
+        "content": "This should not be created due to lack of authorization."
+    }
+
+    response = client.post("/api/v1/terms-and-conditions/", json=test_data)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    app.dependency_overrides.clear()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description
<!--- Describe your changes in detail -->

This PR adds a new POST endpoint to create Terms and Conditions. The endpoint is designed to be used by superadmins to initialize the system's Terms and Conditions.
​

## Related Issue (#738)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR is linked to issue #738 

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Changes
- Added new POST route at `/api/v1/terms-and-conditions/`
- Implemented logic to check for existing Terms and Conditions
- Added creation of new Terms and Conditions if none exist
- Utilized `UpdateTermsAndConditions` schema for input validation
- Implemented proper error handling and success responses

## Implementation Details
The new endpoint:
- Uses dependency injection for database session and superadmin authorization
- Checks if Terms and Conditions already exist before creating new ones
- Creates new Terms and Conditions entry if none exist
- Returns appropriate success or error responses


​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Testing
- Added unit tests to cover:
  - Successful creation scenario
  - Attempt to create when Terms and Conditions already exist
  - Unauthorized access attempt
​

## Screenshots (if appropriate - Postman, etc):

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
