### PR TITLE
Feat:fetch-all-members-in-the-team

### DIFF
--- a/api/v1/routes/team.py
+++ b/api/v1/routes/team.py
@@ -21,6 +21,31 @@ team = APIRouter(prefix="/team", tags=["Teams"])
 
 
 @team.get(
+    '/members',
+    response_model=success_response,
+    status_code=status.HTTP_200_OK
+)
+def get_all_team_members(
+    db: Session = Depends(get_db),
+    su: User = Depends(user_service.get_current_super_admin)
+):
+    '''Endpoint to fetch all team members'''
+    team_members = team_service.fetch_all(db)
+
+    if not team_members:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No team members found"
+        )
+
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message='Team members retrieved successfully',
+        data=jsonable_encoder(team_members),
+    )
+
+
+@team.get(
     '/members/{team_id}',
     response_model=success_response,
     status_code=status.HTTP_200_OK

--- a/api/v1/services/team.py
+++ b/api/v1/services/team.py
@@ -24,9 +24,10 @@ class TeamServices(Service):
 
         return new_member
 
-    def fetch_all(self, db, page, page_size):
-        """Fetch all teams"""
-        pass
+    def fetch_all(self, db: Session):
+        """Fetch all team members"""
+        team_members = db.query(TeamMember).all()
+        return team_members
 
     def fetch(self, db, id):
         """Fetch a single team"""

--- a/tests/v1/team/test_get_all_team_members.py
+++ b/tests/v1/team/test_get_all_team_members.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from main import app
+from api.v1.services.user import user_service
+from api.db.database import get_db
+from sqlalchemy.orm import Session
+from api.v1.services.user import oauth2_scheme
+
+
+def mock_deps():
+    return MagicMock(id="user_id")
+
+
+def mock_db():
+    return MagicMock(spec=Session)
+
+
+def mock_oauth():
+    return 'access_token'
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestGetAllTeamMembers:
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[user_service.get_current_super_admin] = mock_deps
+        app.dependency_overrides[get_db] = mock_db
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Successfully retrieving all team members
+    def test_get_all_team_members_success(self, client):
+        test_members = [
+            {
+                "id": "1",
+                "name": "Mark",
+                "description": "A graphic artist",
+                "role": "admin",
+                "picture_url": "example.com",
+                "team_type": "Executive",
+                "facebook_link": "facebook.com/mark",
+                "instagram_link": "instagram.com/mark",
+                "xtwitter_link": "twitter.com/mark"
+            },
+            {
+                "id": "2",
+                "name": "John",
+                "description": "A software developer",
+                "role": "developer",
+                "picture_url": "example2.com",
+                "team_type": "Development",
+                "facebook_link": "facebook.com/john",
+                "instagram_link": "instagram.com/john",
+                "xtwitter_link": "twitter.com/john"
+            }
+        ]
+
+        with patch('api.v1.services.team.TeamServices.fetch_all') as mock_fetch_all:
+            mock_fetch_all.return_value = test_members
+
+            response = client.get("/api/v1/team/members")
+            assert response.status_code == 200
+            assert response.json()['message'] == "Team members retrieved successfully"
+            assert response.json()['data'] == test_members
+            assert response.json()['success'] == True
+
+    # Handling case where no team members are found
+    def test_get_all_team_members_empty(self, client):
+        with patch('api.v1.services.team.TeamServices.fetch_all') as mock_fetch_all:
+            mock_fetch_all.return_value = []
+
+            response = client.get("/api/v1/team/members")
+            assert response.status_code == 404
+            assert response.json()['message'] == 'No team members found'
+
+    # Handling unauthorized request
+    def test_get_all_team_members_unauthorized(self, client):
+        app.dependency_overrides = {}
+
+        response = client.get("/api/v1/team/members")
+        assert response.status_code == 401
+        assert response.json()['message'] == 'Not authenticated'
+
+    # Handling forbidden request
+    def test_get_all_team_members_forbidden(self, client):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = mock_db
+        app.dependency_overrides[oauth2_scheme] = mock_oauth
+
+        with patch('api.v1.services.user.user_service.get_current_user', return_value=MagicMock(is_super_admin=False)) as cu:
+            response = client.get("/api/v1/team/members")
+        assert response.status_code == 403
+        assert response.json()['message'] == 'You do not have permission to access this resource'


### PR DESCRIPTION
## Title
Add GET `/api/v1/team/members` endpoint to retrieve all team members

## Description
This pull request introduces a new endpoint to fetch all team members and includes the corresponding tests to ensure its functionality. The new endpoint is `/api/v1/team/members`, which allows a super admin to retrieve all members of the team.

## Related Issue (Link to issue ticket)
- Resolves issue #736.

## Motivation and Context
This change is required to provide super admins with the ability to view all team members. It enhances the administrative capabilities of the application and ensures that team management is streamlined and efficient.

## How Has This Been Tested?
- **Unit Tests**: Implemented in `/tests/v1/team/test_get_all_team_members.py`, covering the following scenarios:
  - Successful retrieval of all team members.
  - Handling cases where no team members are found.
  - Unauthorized access to the endpoint.
  - Forbidden access when the user is not a super admin.
- **Manual Testing**: Verified using Postman by making GET requests to `/api/v1/team/members` and checking responses for different scenarios (e.g., authenticated super admin, no team members, etc.).

## Screenshots (if appropriate - Postman, etc):
- ![Success Response](https://github.com/user-attachments/assets/529c07d1-df9f-4557-9e59-1df32b311a60)
- ![404 Error Response](https://github.com/user-attachments/assets/b9b8b2e2-3690-449e-b109-9a5d8ae91b39)
- ![401 Error Response](https://github.com/user-attachments/assets/6fc78d39-09cc-4a9f-8a59-50aef406c257)
- ![403 Error Response](https://github.com/user-attachments/assets/51e19118-eedd-4114-b583-5f19e6e07dd9)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.