### PR TITLE
feat: export organization users' data to csv

### DIFF
--- a/api/v1/services/organization.py
+++ b/api/v1/services/organization.py
@@ -1,3 +1,5 @@
+import csv
+from io import StringIO
 import logging
 from typing import Any, Optional
 from fastapi import HTTPException
@@ -149,7 +151,7 @@ class OrganizationService(Service):
 
     # def add_user_to_organization(self, db: Session, org_id: str, user_id: str):
     def add_user_to_organization(self, schema: AddUpdateOrganizationRole, db: Session):
-        '''Deletes a user from an organization'''
+        '''Adds a user to an organization'''
 
         # Fetch the user and organization
         user = check_model_existence(db, User, schema.user_id)
@@ -263,5 +265,26 @@ class OrganizationService(Service):
             raise HTTPException(status_code=404, detail="Organization not found")
         else:
             return True
+        
+    def export_organization_members(self, db: Session, org_id: str):
+        '''Exports the organization members'''
+
+        org = self.fetch(db=db, id=org_id)
+
+        csv_file = StringIO()
+        csv_writer = csv.writer(csv_file)
+
+        # Write headers
+        csv_writer.writerow(["ID", "First name", 'Last name', "Email", 'Date registered'])
+
+        # Write member data
+        for user in org.users:
+            csv_writer.writerow([user.id, user.first_name, user.last_name, user.email, user.created_at])
+
+        # Move to the beginning of the file
+        csv_file.seek(0)
+
+        return csv_file
+
 
 organization_service = OrganizationService()

--- a/scripts/org_seed.py
+++ b/scripts/org_seed.py
@@ -1,0 +1,69 @@
+import sys, os
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from api.v1.models.user import User
+from api.v1.models.organization import Organization
+from api.v1.models.associations import user_organization_association
+from api.db.database import get_db
+
+# create_database()
+db = next(get_db())
+
+# Create some organizations
+org1 = Organization(
+    company_name="Tech Corp",
+    company_email="contact@techcorp.com",
+    industry="Technology",
+    organization_type="Private",
+    country="USA",
+    state="California",
+    address="123 Tech Lane",
+    lga="San Francisco"
+)
+org2 = Organization(
+    company_name="Health Co",
+    company_email="info@healthco.com",
+    industry="Healthcare",
+    organization_type="Public",
+    country="USA",
+    state="New York",
+    address="456 Health Blvd",
+    lga="Manhattan"
+)
+
+# Add organizations to the session
+db.add_all([org1, org2])
+db.commit()
+
+# Create some users
+user1 = User(
+    email="john.doe@example.com",
+    first_name="John",
+    last_name="Doe",
+    avatar_url="https://example.com/avatar1.png",
+    is_verified=True,
+)
+user2 = User(
+    email="jane.smith@example.com",
+    first_name="Jane",
+    last_name="Smith",
+    avatar_url="https://example.com/avatar2.png",
+    is_verified=True,
+)
+
+# Add users to the session
+db.add_all([user1, user2])
+db.commit()
+
+# Add users to organizations with roles
+stmt = user_organization_association.insert().values([
+    {'user_id': user1.id, 'organization_id': org1.id, 'role': 'admin', 'status': 'member'},
+    {'user_id': user2.id, 'organization_id': org1.id, 'role': 'user', 'status': 'member'},
+    {'user_id': user2.id, 'organization_id': org2.id, 'role': 'owner', 'status': 'member'},
+])
+
+db.execute(stmt)
+db.commit()

--- a/tests/v1/faq/delete_faq_test.py
+++ b/tests/v1/faq/delete_faq_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+from fastapi import HTTPException
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -86,3 +87,23 @@ def test_delete_faq_unauthorized(client, db_session_mock):
 
     assert response.status_code == 401
 
+
+def test_faq_not_found(client, db_session_mock):
+    """Test when the FAQ ID does not exist."""
+
+    # Mock the user service to return the current super admin user
+    app.dependency_overrides[user_service.get_current_super_admin] = mock_get_current_admin
+    app.dependency_overrides[faq_service.fetch] = lambda: mock_faq
+
+    # Simulate a non-existent organization
+    nonexistent_id = str(uuid7())
+
+    # Mock the organization service to raise an exception for a non-existent FAQ
+    with patch("api.v1.services.faq.faq_service.fetch", side_effect=HTTPException(status_code=404, detail="FAQ not found")):
+        response = client.delete(
+            f'/api/v1/faqs/{nonexistent_id}',
+            headers={'Authorization': 'Bearer valid_token'}
+        )
+
+        # Assert that the response status code is 404 Not Found
+        assert response.status_code == 404

--- a/tests/v1/faq/get_single_faq_test.py
+++ b/tests/v1/faq/get_single_faq_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+from fastapi import HTTPException
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -72,3 +73,24 @@ def test_fetch_faq_success(client, db_session_mock):
         )
 
         assert response.status_code == 200
+
+
+def test_faq_not_found(client, db_session_mock):
+    """Test when the FAQ ID does not exist."""
+
+    # Mock the user service to return the current super admin user
+    app.dependency_overrides[user_service.get_current_super_admin] = mock_get_current_admin
+    app.dependency_overrides[faq_service.fetch] = lambda: mock_faq
+
+    # Simulate a non-existent organization
+    nonexistent_id = str(uuid7())
+
+    # Mock the organization service to raise an exception for a non-existent FAQ
+    with patch("api.v1.services.faq.faq_service.fetch", side_effect=HTTPException(status_code=404, detail="FAQ not found")):
+        response = client.get(
+            f'/api/v1/faqs/{nonexistent_id}',
+            headers={'Authorization': 'Bearer valid_token'}
+        )
+
+        # Assert that the response status code is 404 Not Found
+        assert response.status_code == 404

--- a/tests/v1/faq/update_faq_test.py
+++ b/tests/v1/faq/update_faq_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+from fastapi import HTTPException
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -120,3 +121,28 @@ def test_update_faq_unauthorized(client, db_session_mock):
 
     assert response.status_code == 401
 
+
+def test_faq_not_found(client, db_session_mock):
+    """Test when the FAQ ID does not exist."""
+
+    # Mock the user service to return the current super admin user
+    app.dependency_overrides[user_service.get_current_super_admin] = mock_get_current_admin
+    app.dependency_overrides[faq_service.fetch] = lambda: mock_faq
+
+    # Simulate a non-existent organization
+    nonexistent_id = str(uuid7())
+
+    # Mock the organization service to raise an exception for a non-existent FAQ
+    with patch("api.v1.services.faq.faq_service.fetch", side_effect=HTTPException(status_code=404, detail="FAQ not found")):
+        response = client.patch(
+            f'/api/v1/faqs/{nonexistent_id}',
+            headers={'Authorization': 'Bearer valid_token'},
+            json={
+                "question": "Question?",
+                "answer": "Answer",
+            }
+        )
+
+        # Assert that the response status code is 404 Not Found
+        assert response.status_code == 404
+        

--- a/tests/v1/organization/test_export_user_data.py
+++ b/tests/v1/organization/test_export_user_data.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timezone
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.db.database import get_db
+from api.v1.models.organization import Organization
+from api.v1.services.user import user_service
+from api.v1.models import User
+from api.v1.services.organization import organization_service
+from main import app
+
+
+def mock_get_current_user():
+    return User(
+        id=str(uuid7()),
+        email="testuser@gmail.com",
+        password=user_service.hash_password("Testpassword@123"),
+        first_name='Test',
+        last_name='User',
+        is_active=True,
+        is_super_admin=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+
+def mock_get_current_admin():
+    return User(
+        id=str(uuid7()),
+        email="admin@gmail.com",
+        password=user_service.hash_password("Testadmin@123"),
+        first_name='Admin',
+        last_name='User',
+        is_active=True,
+        is_super_admin=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+
+def mock_organization():
+    return Organization(
+        id=str(uuid7()),
+        company_name="Health Co",
+        company_email="info@healthco.com",
+        industry="Healthcare",
+        organization_type="Public",
+        country="USA",
+        state="New York",
+        address="456 Health Blvd",
+        lga="Manhattan",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+
+def mock_csv_content():
+    # Create a sample CSV content
+    sample_csv_content = StringIO()
+    sample_csv_content.write("ID,First name,Last name,Email,Date registered\n")
+    sample_csv_content.write("1,John,Doe,john@example.com,2024-08-05T12:34:56\n")
+    sample_csv_content.seek(0)
+
+    return sample_csv_content
+
+
+
+@pytest.fixture
+def db_session_mock():
+    db_session = MagicMock(spec=Session)
+    return db_session
+
+@pytest.fixture
+def client(db_session_mock):
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides = {}
+
+
+def test_export_success(client, db_session_mock):
+    '''Test to successfully export user data in an organization'''
+
+    # Mock the user service to return the current user
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: mock_get_current_admin
+    # app.dependency_overrides[organization_service.fetch] = lambda: mock_organization
+
+    mock_org = mock_organization()
+    db_session_mock.add(mock_org)
+    db_session_mock.commit()
+
+    mock_csv = mock_csv_content()
+
+    with patch("api.v1.services.organization.organization_service.export_organization_members", return_value=mock_csv) as mock_export:
+        response = client.get(
+            f'/api/v1/organizations{mock_org.id}/users/export',
+            headers={'Authorization': 'Bearer token'}
+        )
+
+        # Assert the response status code
+        assert response.status_code == 200
+
+
+def test_export_unauthorized(client, db_session_mock):
+    '''Test for unauthorized user'''
+
+    mock_org = mock_organization()
+    db_session_mock.add(mock_org)
+    db_session_mock.commit()
+    
+    response = client.get(
+        f'/api/v1/organizations{mock_org.id}/users/export',
+        headers={'Authorization': 'Bearer token'}
+    )
+
+    assert response.status_code == 401
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
What I have done here is to add an endpoint to export relevant user data for users in a certain organization. This endpoint is a GET request: `/api/v1/organizations/{org_id}/users/export`
​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Link to issue](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/752)
​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The change provides an added level of functionality to the entire application as a whole. As the endpoint is triggered, the csv data is downloaded immediately for the user to make use of.
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with Postman and Pytest to cover all scenarios and edge cases


## Screenshots (if appropriate - Postman, etc):

Successful response
​
![image](https://github.com/user-attachments/assets/2d5e3d3e-a437-4e4d-a5d9-0da889a73c8a)

Organization not found error

![image](https://github.com/user-attachments/assets/80f903e2-8cdc-467f-9afc-8c501a738ee0)

Pytest

![image](https://github.com/user-attachments/assets/0ada3570-52f9-464e-8689-4fe634a0b22f)
​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
