### PR TITLE
feat: endpoint to delete invites (superadmin)

### DIFF
--- a/api/v1/routes/invitations.py
+++ b/api/v1/routes/invitations.py
@@ -5,6 +5,7 @@ from api.v1.schemas import invitations
 from api.db.database import get_db as get_session
 from api.v1.services import invite
 from api.v1.models.user import User
+from api.utils.success_response import success_response
 from api.v1.services.user import user_service
 import logging
 
@@ -43,3 +44,26 @@ async def add_user_to_organization(
     logging.info(f"Processing invitation ID: {invite_id}")
 
     return invite.InviteService.add_user_to_organization(invite_id, session)
+
+@invites.delete("/{invite_id}", status_code=200, response_model=success_response)
+def delete_invite(
+    invite_id: str,
+    db: Session = Depends(get_session), 
+    admin: User = Depends(user_service.get_current_super_admin)
+):
+    """ Delete invite from database """
+    if invite_id.strip() == "":
+        logging.warning(f"Invitation ID not found in path parameter.")
+        raise HTTPException(status_code=404, detail="Invite id is absent")
+    
+    invite_is_deleted = invite.InviteService.delete(db, invite_id)
+
+    if not invite_is_deleted:
+        raise HTTPException(status_code=404, detail="Invalid invitation id")
+
+    logging.info(f"Deleted invite. ID: {invite_id}")
+
+    return success_response(
+        status_code=200,
+        message='Invite deleted successfully',
+    )

--- a/api/v1/routes/invitations.py
+++ b/api/v1/routes/invitations.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 from urllib.parse import urlparse, parse_qs
 from api.v1.schemas import invitations
@@ -45,7 +45,7 @@ async def add_user_to_organization(
 
     return invite.InviteService.add_user_to_organization(invite_id, session)
 
-@invites.delete("/{invite_id}", status_code=200, response_model=success_response)
+@invites.delete("/{invite_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_invite(
     invite_id: str,
     db: Session = Depends(get_session), 
@@ -58,8 +58,3 @@ def delete_invite(
         raise HTTPException(status_code=404, detail="Invalid invitation id")
 
     logging.info(f"Deleted invite. ID: {invite_id}")
-
-    return success_response(
-        status_code=200,
-        message='Invite deleted successfully',
-    )

--- a/api/v1/routes/invitations.py
+++ b/api/v1/routes/invitations.py
@@ -52,10 +52,6 @@ def delete_invite(
     admin: User = Depends(user_service.get_current_super_admin)
 ):
     """ Delete invite from database """
-    if invite_id.strip() == "":
-        logging.warning(f"Invitation ID not found in path parameter.")
-        raise HTTPException(status_code=404, detail="Invite id is absent")
-    
     invite_is_deleted = invite.InviteService.delete(db, invite_id)
 
     if not invite_is_deleted:

--- a/api/v1/services/invite.py
+++ b/api/v1/services/invite.py
@@ -161,3 +161,14 @@ class InviteService(Service):
         session.delete(invite)
         session.commit()
         return True
+    
+    def fetch(self):
+        pass
+
+    def fetch_all(self):
+        pass
+
+    def update(self):
+        pass
+    
+invite_service = InviteService()

--- a/api/v1/services/invite.py
+++ b/api/v1/services/invite.py
@@ -11,10 +11,11 @@ from api.v1.models.organization import Organization
 from api.v1.models.user import User
 from api.v1.models.associations import user_organization_association
 from api.v1.schemas import invitations
+from api.core.base.services import Service
 from urllib.parse import urlencode
 
 
-class InviteService:
+class InviteService(Service):
     @staticmethod
     def create(
         invite: invitations.InvitationCreate, request: Request, session: Session
@@ -139,5 +140,24 @@ class InviteService:
                 status_code=500,
                 detail="An error occurred while adding the user to the organization",
             )
+    @staticmethod
+    def delete(session: Session, id: str):
+        """Function to delete invite link
+        
+        Args:
+            session(Session): The current ORM session object.
+            id(str): Invite id string
 
-invite_service = InviteService()
+        Returns:
+            True if delete is successful else False
+        
+        """
+        invite = (
+            session.query(Invitation).filter_by(id=id).first()
+        )
+        
+        if invite is None:
+            return False
+        session.delete(invite)
+        session.commit()
+        return True

--- a/tests/v1/invitation/test_delete_invitation.py
+++ b/tests/v1/invitation/test_delete_invitation.py
@@ -47,15 +47,6 @@ class TestCodeUnderTest:
         assert response.json()['success'] == True
 
 
-
-    # Invite id path parameter absent
-    def test_delete_invite_empty_id(self, client):
-        
-        response = client.delete("/api/v1/invite/ ")
-        
-        assert response.status_code == 404
-        assert response.json()['message'] == "Invite id is absent"
-
     # Invalid invite id
     def test_delete_invite_invalid_id(self, client):
         

--- a/tests/v1/invitation/test_delete_invitation.py
+++ b/tests/v1/invitation/test_delete_invitation.py
@@ -1,0 +1,85 @@
+# Dependencies:
+# pip install pytest-mock
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from main import app
+from api.v1.services.user import user_service
+from api.db.database import get_db
+from sqlalchemy.orm import Session
+from datetime import datetime
+from api.v1.services.user import oauth2_scheme
+
+
+def mock_deps():
+    return MagicMock(id="user_id")
+
+def mock_oauth():
+    return 'access_token'
+
+def mock_db():
+    return MagicMock(spec=Session)
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+DELETE_ENDPOINT = "/api/v1/invite/invite_id"
+class TestCodeUnderTest:
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[user_service.get_current_super_admin] = mock_deps
+        app.dependency_overrides[get_db] = mock_db
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Successfully delete invite from to the database
+    def test_delete_invite_success(self, client):
+        
+        response = client.delete(DELETE_ENDPOINT)
+        
+        assert response.status_code     == 200
+        assert response.json()['message'] == "Invite deleted successfully"
+        assert response.json().get('data') == None
+        assert response.json()['success'] == True
+
+
+
+    # Invite id path parameter absent
+    def test_delete_invite_empty_id(self, client):
+        
+        response = client.delete("/api/v1/invite/ ")
+        
+        assert response.status_code == 404
+        assert response.json()['message'] == "Invite id is absent"
+
+    # Invalid invite id
+    def test_delete_invite_invalid_id(self, client):
+        
+        
+        with patch('api.v1.services.invite.InviteService.delete', return_value=False) as tmp:
+            response = client.delete(DELETE_ENDPOINT)
+            assert response.status_code == 404
+            assert response.json()['message'] == "Invalid invitation id"
+
+    # Handling unauthorized request
+    def test_delete_invite_unauth(self, client):
+        app.dependency_overrides = {}
+
+        response = client.delete(DELETE_ENDPOINT)
+        assert response.status_code == 401
+        assert response.json()['message'] == 'Not authenticated'
+
+  # Handling forbidden request
+    def test_delete_invite_forbidden(self, client):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = mock_db
+        app.dependency_overrides[oauth2_scheme] = mock_oauth
+
+        with patch('api.v1.services.user.user_service.get_current_user', return_value=MagicMock(is_super_admin=False)) as cu:
+            response = client.delete(DELETE_ENDPOINT)
+            assert response.status_code == 403
+            assert response.json()['message'] == 'You do not have permission to access this resource'

--- a/tests/v1/invitation/test_delete_invitation.py
+++ b/tests/v1/invitation/test_delete_invitation.py
@@ -41,11 +41,7 @@ class TestCodeUnderTest:
         
         response = client.delete(DELETE_ENDPOINT)
         
-        assert response.status_code     == 200
-        assert response.json()['message'] == "Invite deleted successfully"
-        assert response.json().get('data') == None
-        assert response.json()['success'] == True
-
+        assert response.status_code == 204
 
     # Invalid invite id
     def test_delete_invite_invalid_id(self, client):


### PR DESCRIPTION
 ## Description
Create an API endpoint to allow superadmins delete invites.
This endpoint will validate the invite id and then delete the invite from the database.
​

The changes include:
 
* **Endpoint Addition:** Added `DELETE /api/v1/invite/{invite_id}` for deleting invites.
* **Error Handling:** Implemented checks for invalid invitation id and unauthorized access.
* **Testing:** Added `pytest` cases to ensure functionality and edge cases are covered.
 
 
## Related Issue (Link to issue ticket)
[Issue Ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/779)


 ## Motivation and Context
This feature is essential to enable superadmins delete invites from the database.
 
 ## How Has This Been Tested?
 * **Unit Tests:** Added tests to validate the deletion of invites from the database, authorization failures and invalid request body.
* **Test Environment:** Tests were run using a mocked database instance to avoid interference with the production environment.

Tests include:
 
* Deleting valid invitations.
* Handling invalid invalid id parameter
* Handling unauthorized access.

## Screenshots:
### Successful Request


### Invalid id parameter
![image](https://github.com/user-attachments/assets/90ea1953-e960-4207-8a12-43b6eb812719)


### Unauthorized Request
![image](https://github.com/user-attachments/assets/ab5de68f-da06-44df-a405-8a0372b8ee98)


## Types of changes
* [x]  New feature (non-breaking change which adds functionality)
 
 ## Checklist:
 * [x]  My code follows the code style of this project.
 * [x]  My change requires a change to the documentation.
 * [x]  I have updated the documentation accordingly.
 * [x]  I have read the **CONTRIBUTING** document.
 * [x]  I have added tests to cover my changes.
 * [x]  All new and existing tests passed.