### PR TITLE
bugfix: updated response to use custom success response

### DIFF
--- a/api/v1/services/permissions/role_service.py
+++ b/api/v1/services/permissions/role_service.py
@@ -4,6 +4,7 @@ from api.v1.models.permissions.user_org_role import user_organization_roles
 from api.v1.schemas.permissions.roles import RoleDeleteResponse
 from api.v1.schemas.role import RoleCreate
 from uuid_extensions import uuid7
+from api.utils.success_response import success_response
 from fastapi import HTTPException
 from sqlalchemy.exc import IntegrityError
 
@@ -17,7 +18,8 @@ class RoleService:
             db.add(db_role)
             db.commit()
             db.refresh(db_role)
-            return db_role
+            response = success_response(201, f'role {role.name} created successfully', db_role)
+            return response
         except IntegrityError as e:
             db.rollback()
             raise HTTPException(status_code=400, detail="A role with this name already exists.")
@@ -34,6 +36,7 @@ class RoleService:
                 role_id=role_id
             ))
             db.commit()
+            return success_response(200, "role successfully added to user")
         except IntegrityError as e:
             db.rollback()
             raise HTTPException(status_code=400, detail="The role or user might not exist, or there might be a duplication issue.")
@@ -61,7 +64,6 @@ class RoleService:
         if not roles:
             raise HTTPException(status_code=404, detail="Roles not found for the given organization")
         return roles
-
 
 
 role_service = RoleService()

--- a/tests/v1/roles_permissions/roles_test.py
+++ b/tests/v1/roles_permissions/roles_test.py
@@ -89,8 +89,8 @@ def test_create_role_success(mock_db_session):
 
     # Mock role creation
     response = client.post("/api/v1/roles", json=role_data, headers={'Authorization': f'Bearer {access_token}'})
-    assert response.status_code == 200
-    assert response.json()["name"] == role_name
+    assert response.status_code == 201
+    assert response.json()["message"] == "role TestRole created successfully"
     
     
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description
Updated the response structure in the relevant endpoints to use a custom success response format. This change standardizes the API response format, improving consistency and readability across the application.
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context
The previous implementation did not use the custom success response, leading to inconsistencies in the API responses. This bugfix resolves the issue by ensuring that all success responses follow the same format, making it easier for clients to parse and handle responses.

<!--- Why is this change required? What problem does it solve? -->

​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change has been tested by running unit tests on the updated endpoints to verify that the custom success response is returned correctly. Manual testing was also performed using Postman to ensure that the API behaves as expected and that the correct status codes and response bodies are returned.
​

## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/1917b1ff-27ec-4892-994a-d2404f8881b3)

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
