### PR TITLE
feat: update billing plan by plan_id

### DIFF
--- a/api/v1/routes/billing_plan.py
+++ b/api/v1/routes/billing_plan.py
@@ -33,7 +33,6 @@ async def retrieve_all_billing_plans(
         },
     )
 
-
 @bill_plan.post("/billing-plans", response_model=success_response)
 async def create_new_billing_plan(
     request: CreateSubscriptionPlan,
@@ -51,3 +50,23 @@ async def create_new_billing_plan(
         message="Plans created successfully",
         data=jsonable_encoder(plan),
     )
+
+@bill_plan.patch('/billing-plans/{billing_plan_id}', response_model=success_response)
+async def update_a_billing_plan(
+    billing_plan_id: str,
+    request: CreateSubscriptionPlan,
+    current_user: User = Depends(user_service.get_current_super_admin),
+    db: Session = Depends(get_db)
+):
+    """
+    Endpoint to update a billing plan by ID
+    """
+
+    plan = billing_plan_service.update(db=db, id=billing_plan_id, schema=request)
+
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Plan updated successfully",
+        data=jsonable_encoder(plan),
+    )
+

--- a/api/v1/services/billing_plan.py
+++ b/api/v1/services/billing_plan.py
@@ -3,6 +3,7 @@ from api.v1.models.billing_plan import BillingPlan
 from typing import Any, Optional
 from api.core.base.services import Service
 from api.v1.schemas.plans import CreateSubscriptionPlan
+from api.utils.db_validators import check_model_existence
 
 
 class BillingPlanService(Service):
@@ -26,8 +27,20 @@ class BillingPlanService(Service):
     def fetch():
         pass
 
-    def update():
-        pass
+    def update(self, db: Session, id: str, schema):
+        """
+        fetch and update a billing plan
+        """
+        plan = check_model_existence(db, BillingPlan, id)
+
+        update_data = schema.dict(exclude_unset=True)
+        for column, value in update_data.items():
+            setattr(plan, column, value)
+
+        db.commit()
+        db.refresh(plan)
+
+        return plan
 
     def fetch_all(self, db: Session, **query_params: Optional[Any]):
         """Fetch all products with option tto search using query parameters"""

--- a/tests/v1/billing_plan/test_update_billing_plan.py
+++ b/tests/v1/billing_plan/test_update_billing_plan.py
@@ -1,0 +1,75 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from main import app
+from api.v1.models.user import User
+from api.v1.services.user import user_service
+from uuid_extensions import uuid7
+from api.db.database import get_db
+from fastapi import status
+from datetime import datetime, timezone
+
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_db_session():
+    """Fixture to create a mock database session."""
+
+    with patch("api.v1.services.user.get_db", autospec=True) as mock_get_db:
+        mock_db = MagicMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        yield mock_db
+    app.dependency_overrides = {}
+
+
+@pytest.fixture
+def mock_user_service():
+    """Fixture to create a mock user service."""
+
+    with patch("api.v1.services.user.user_service", autospec=True) as mock_service:
+        yield mock_service
+
+
+def create_mock_user(mock_user_service, mock_db_session):
+    """Create a mock user in the mock database session."""
+    mock_user = User(
+        id=str(uuid7()),
+        email="testuser@gmail.com",
+        password=user_service.hash_password("Testpassword@123"),
+        first_name='Test',
+        last_name='User',
+        is_active=True,
+        is_super_admin=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc)
+    )
+    mock_db_session.query.return_value.filter.return_value.first.return_value = mock_user
+    return mock_user
+
+@pytest.mark.usefixtures("mock_db_session", "mock_user_service")
+def test_update_billing_plan(mock_user_service, mock_db_session):
+    """Billing plan update test."""
+    mock_user = create_mock_user(mock_user_service, mock_db_session)
+    access_token = user_service.create_access_token(user_id=str(uuid7()))
+    data = {
+            "name": "Advanced",
+            "organization_id": "s2334d",
+            "description": "All you need in one pack",
+            "price": 80,
+            "duration": "Monthly",
+            "currency": "Naira",
+            "features": [
+                "Multiple team",
+                "Premium support"
+            ]
+            }
+    
+    response = client.patch(
+        "/api/v1/organizations/billing-plans/123-1221-090",
+        headers={'Authorization': f'Bearer {access_token}'},
+        json=data
+        )
+    
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
The endpoint will update the billing plan using the plan's ID. **PATCH api/v1/organization/billing-plans/{plan_id} [PROTECTED]**

## Description
Implemented an endpoint to update a specific billing plan

## Related Issue (Link to issue ticket)
[Issue link](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/796)

## How Has This Been Tested?
Different testing coverage was made with Postman
​
## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/62c1ee9f-c02b-4583-8a6d-acbab9a00b5a)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
