### PR TITLE
feat: Fetch All Product Comments

### DIFF
--- a/api/v1/routes/permissions/roles.py
+++ b/api/v1/routes/permissions/roles.py
@@ -92,6 +92,7 @@ def delete_role(
     db: Session = Depends(get_db),
     current_user: User = Depends(user_service.get_current_user)
 ):
+    """ An endpoint that fetches all product comment"""
     role_service.delete_role(db, role_id)
     return success_response(status_code=200, message="Role successfully deleted.", data={"id": role_id})
        

--- a/api/v1/routes/product_comment.py
+++ b/api/v1/routes/product_comment.py
@@ -27,9 +27,25 @@ def get_product_comment(
     db: Session = Depends(get_db),
     current_user: User = Depends(user_service.get_current_user),
 ):
+    """ An endpoint that fetches a single product comment"""
     comment = product_comment_service.fetch(db=db, id=comment_id)
     return success_response(
         status_code=status.HTTP_200_OK,
         message="Comment fetched successfully",
         data=jsonable_encoder(comment),
+    )
+    
+    
+@product_comment.get("/{product_id}/comments", response_model=List[ProductCommentResponse], status_code=status.HTTP_200_OK)
+def get_all_product_comments(
+    product_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user),
+):
+    """ An endpoint that fetches all product comment"""
+    comments = product_comment_service.fetch_all(db=db, product_id=product_id)
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Comments fetched successfully",
+        data=jsonable_encoder(comments),
     )

--- a/tests/v1/product/test_product_comment.py
+++ b/tests/v1/product/test_product_comment.py
@@ -84,7 +84,7 @@ def client(db_session_mock):
 
 
 def test_fetch_single_product_comment(client, db_session_mock):
-    '''Test to successfully update a job'''
+    '''Test to successfully fetch a single product comment'''
 
     # Mock the user service to return the current user
     app.dependency_overrides[user_service.get_current_user] = lambda: mock_get_current_admin()
@@ -113,3 +113,29 @@ def test_fetch_single_product_comment(client, db_session_mock):
         
 
 
+
+def test_fetch_all_product_comment(client, db_session_mock):
+    '''Test to successfully fetch all product comment'''
+
+    # Mock the user service to return the current user
+    app.dependency_overrides[user_service.get_current_user] = lambda: mock_get_current_admin()
+    app.dependency_overrides[product_service.create] = lambda: mock_product()
+    app.dependency_overrides[product_comment_service.create] = lambda: mock_product_comment()
+    app.dependency_overrides[product_comment_service.fetch_all] = lambda: mock_product_comment()
+
+    
+    # Mock job update
+    db_session_mock.add.return_value = None
+    db_session_mock.commit.return_value = None
+    db_session_mock.refresh.return_value = None
+
+    mock_product_instance = mock_product()
+    
+    
+    response = client.get(
+            f"/api/v1/products/{mock_product_instance.id}/comments",
+            headers={'Authorization': 'Bearer token'}
+        )
+
+    assert response.status_code == 200
+        


### PR DESCRIPTION
## Description

This PR implements the feature `api/v1/{product_id}/comments` to fetch all comments for a specific product. The endpoint has been adjusted to retrieve a list of all comments associated with a given product ID. Mocked services are used to test this functionality, ensuring that the correct data structure is returned with the appropriate status code.

## Related Issue (Link to issue ticket)

This PR is related to [Issue #812](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/812) 

## Motivation and Context

This change is required to allow users to retrieve all comments for a specific product in the system. It enhances the functionality by providing a way to gather feedback and reviews from users, which is essential for product evaluation.

## How Has This Been Tested?

This feature has been tested by creating unit tests using Pytest and MagicMock. The tests cover scenarios such as successful fetching of comments, verifying the response structure, and ensuring the correct status code is returned. The environment used for testing includes Python 3.10, FastAPI, and SQLAlchemy.

## Screenshots (if appropriate - Postman, etc):

![fetchAllproductComment](https://github.com/user-attachments/assets/39011c9b-74fa-4438-bb5e-3a0f807bdff0)


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
