### PR TITLE
feat:  get current user organizations

### DIFF
--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -4,7 +4,7 @@ from api.v1.routes.team import team
 from fastapi import APIRouter
 from api.v1.routes.auth import auth
 from api.v1.routes.newsletter import newsletter
-from api.v1.routes.user import user
+from api.v1.routes.user import user_router
 from api.v1.routes.product import product
 from api.v1.routes.product_comment import product_comment
 from api.v1.routes.notification import notification
@@ -50,7 +50,7 @@ api_version_one.include_router(auth)
 api_version_one.include_router(google_auth)
 api_version_one.include_router(fb_auth)
 api_version_one.include_router(pwd_reset)
-api_version_one.include_router(user)
+api_version_one.include_router(user_router)
 api_version_one.include_router(profile)
 api_version_one.include_router(organization)
 api_version_one.include_router(product)

--- a/api/v1/services/user.py
+++ b/api/v1/services/user.py
@@ -114,6 +114,12 @@ class UserService(Service):
         if not user.is_deleted:
             return user
 
+    def get_user_by_id(self, db: Session, id: str):
+        """Fetches a user by their id"""
+
+        user = check_model_existence(db, User, id)
+        return user
+
     def fetch_by_email(self, db: Session, email):
         """Fetches a user by their email"""
 

--- a/tests/v1/user/test_get_current_user_organizations.py
+++ b/tests/v1/user/test_get_current_user_organizations.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.db.database import get_db
+from api.v1.models.organization import Organization
+from api.v1.services.user import user_service
+from api.v1.models import User
+from main import app
+
+
+# Mock user with organizations
+def mock_get_current_user():
+    # Create mock organizations
+    org1 = Organization(id=str(uuid7()), name="Organization One")
+    org2 = Organization(id=str(uuid7()), name="Organization Two")
+
+    # Create mock user
+    mock_user = User(
+        id=str(uuid7()),
+        email="user@gmail.com",
+        password=user_service.hash_password("Testuser@123"),
+        first_name='Admin',
+        last_name='User',
+        is_active=True,
+        is_super_admin=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        organizations=[org1, org2]
+    )
+    return mock_user
+
+
+@pytest.fixture
+def db_session_mock():
+    db_session = MagicMock(spec=Session)
+    return db_session
+
+@pytest.fixture
+def client(db_session_mock):
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides = {}
+
+
+def test_get_user_organizations_unauthorized(client, db_session_mock):
+    '''Test unauthorized response'''
+
+    response = client.get(
+        '/api/v1/users/organisations',
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
The change I have made is to get the organizations the current user belongs to. The endpoint accepts a GET reqyest. THis is the endpoint:
`/api/v1/users/organisations`
​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Link to issue](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/519)
​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Th s solves the problem of not being able to get all the organizations you belong in as a current user
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with Postman and Pytest
​

## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/edf20870-f161-41ad-8efd-8feb0e2f948d)
![image](https://github.com/user-attachments/assets/7e44ea3c-c916-4fc8-9e7f-20a16aa352e2)
​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
