### PR TITLE
fix: Fixed password update endpoint

### DIFF
--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -11,7 +11,7 @@ from api.v1.models import User
 from api.v1.schemas.user import Token
 from api.v1.schemas.user import LoginRequest, UserCreate, EmailRequest
 from api.v1.schemas.token import TokenRequest
-from api.v1.schemas.user import UserCreate, MagicLinkRequest
+from api.v1.schemas.user import UserCreate, MagicLinkRequest, ChangePasswordSchema
 from api.v1.services.organisation import organisation_service
 from api.v1.schemas.organisation import CreateUpdateOrganisation
 from api.db.database import get_db
@@ -300,3 +300,17 @@ async def verify_magic_link(token_schema: Token, db: Session = Depends(get_db)):
     )
 
     return response
+
+@auth.patch("/change-password", status_code=200)
+async def change_password(
+    schema: ChangePasswordSchema,
+    db: Session = Depends(get_db),
+    user: User = Depends(user_service.get_current_user),
+):
+    """Endpoint to change the user's password"""
+    user_service.change_password(new_password=schema.new_password,
+                                 user=user,
+                                 db=db,
+                                 old_password=schema.old_password)
+
+    return success_response(status_code=200, message="Password changed successfully")

--- a/api/v1/routes/user.py
+++ b/api/v1/routes/user.py
@@ -7,7 +7,6 @@ from api.utils.success_response import success_response
 from api.v1.models.user import User
 from api.v1.schemas.user import (
     DeactivateUserSchema,
-    ChangePasswordSchema,
     ChangePwdRet, AllUsersResponse, UserUpdate,
     AdminCreateUserResponse, AdminCreateUser
 )
@@ -51,20 +50,6 @@ async def delete_account(request: Request, db: Session = Depends(get_db), curren
         status_code=200,
         message='User deleted successfully',
     )
-
-
-@user_router.patch("/me/password", status_code=200)
-async def change_password(
-    schema: ChangePasswordSchema,
-    db: Session = Depends(get_db),
-    user: User = Depends(user_service.get_current_user),
-):
-    """Endpoint to change the user's password"""
-
-    user_service.change_password(schema.old_password, schema.new_password, user, db)
-
-    return success_response(status_code=200, message="Password changed successfully")
-
 
 @user_router.patch("/",status_code=status.HTTP_200_OK)
 def update_current_user(

--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -1,8 +1,11 @@
 import re
 from datetime import datetime
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Annotated
 
-from pydantic import BaseModel, EmailStr, field_validator, ConfigDict
+from pydantic import (BaseModel, EmailStr,
+                      field_validator, ConfigDict,
+                      StringConstraints,
+                      model_validator)
 
 
 class UserBase(BaseModel):
@@ -19,21 +22,35 @@ class UserCreate(BaseModel):
     """Schema to create a user"""
 
     email: EmailStr
-    password: str
+    password: Annotated[
+        str, StringConstraints(
+            min_length=8,
+            max_length=64,
+            strip_whitespace=True
+        )
+    ]
     first_name: str
     last_name: str
 
-    @field_validator("password")
+    @model_validator(mode='before')
     @classmethod
-    def password_validator(cls, value):
-        if not re.match(
-            r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$",
-            value,
-        ):
-            raise ValueError(
-                "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit and one special character."
-            )
-        return value
+    def validate_password(cls, values: dict):
+        """
+        Validates passwords
+        """
+        password = values.get('password')
+
+        # constraints for password
+        if not any(c.islower() for c in password):
+            raise ValueError("password must include at least one lowercase character")
+        if not any(c.isupper() for c in password):
+            raise ValueError("password must include at least one uppercase character")
+        if not any(c.isdigit() for c in password):
+            raise ValueError("password must include at least one digit")
+        if not any(c in ['!','@','#','$','%','&','*','?','_','-'] for c in password):
+            raise ValueError("password must include at least one special character")
+        
+        return values
 
 class UserUpdate(BaseModel):
     
@@ -125,8 +142,53 @@ class DeactivateUserSchema(BaseModel):
 class ChangePasswordSchema(BaseModel):
     """Schema for changing password of a user"""
 
-    old_password: str
-    new_password: str
+    old_password: Annotated[
+        Optional[str],
+        StringConstraints(min_length=8,
+                          max_length=64,
+                          strip_whitespace=True)
+    ] = None
+
+    new_password: Annotated[
+        str,
+        StringConstraints(min_length=8,
+                          max_length=64,
+                          strip_whitespace=True)
+    ]
+
+    @model_validator(mode='before')
+    @classmethod
+    def validate_password(cls, values: dict):
+        """
+        Validates passwords
+        """
+        old_password = values.get('old_password')
+        new_password = values.get('new_password')
+
+        if (old_password and old_password.strip() == '') or old_password == '':
+            values['old_password'] = None
+        # constraints for old_password
+        if old_password and old_password.strip():
+            if not any(c.islower() for c in old_password):
+                raise ValueError("Old password must include at least one lowercase character")
+            if not any(c.isupper() for c in old_password):
+                raise ValueError("Old password must include at least one uppercase character")
+            if not any(c.isdigit() for c in old_password):
+                raise ValueError("Old password must include at least one digit")
+            if not any(c in ['!','@','#','$','%','&','*','?','_','-'] for c in old_password):
+                raise ValueError("Old password must include at least one special character")
+
+        # constraints for new_password
+        if not any(c.islower() for c in new_password):
+            raise ValueError("New password must include at least one lowercase character")
+        if not any(c.isupper() for c in new_password):
+            raise ValueError("New password must include at least one uppercase character")
+        if not any(c.isdigit() for c in new_password):
+            raise ValueError("New password must include at least one digit")
+        if not any(c in ['!','@','#','$','%','&','*','?','_','-'] for c in new_password):
+            raise ValueError("New password must include at least one special character")
+        
+        return values
 
 
 class ChangePwdRet(BaseModel):

--- a/tests/v1/user/change_user_password_test.py
+++ b/tests/v1/user/change_user_password_test.py
@@ -108,7 +108,7 @@ def test_user_password(mock_db_session, mock_user_service):
     user_pwd_change = client.patch(
         CHANGE_PWD_ENDPOINT,
         json={"old_password": "Testpassword@123",
-              "new_password": "Ojobonandom@123"},
+              "new_password": "Testpassword@1234"},
         headers={"Authorization": f"Bearer {access_token}"},
     )
 

--- a/tests/v1/user/change_user_password_test.py
+++ b/tests/v1/user/change_user_password_test.py
@@ -12,7 +12,8 @@ from datetime import datetime, timezone
 client = TestClient(app)
 LOGIN_ENDPOINT = "api/v1/auth/login"
 CHANGE_PWD_ENDPOINT = "/api/v1/auth/change-password"
-
+p1 = "Testpassword@123"
+p2 = "Testpassword@1234"
 
 @pytest.fixture
 def mock_db_session():
@@ -107,8 +108,8 @@ def test_user_password(mock_db_session, mock_user_service):
 
     user_pwd_change = client.patch(
         CHANGE_PWD_ENDPOINT,
-        json={"old_password": "Testpassword@123",
-              "new_password": "Testpassword@1234"},
+        json={"old_password": p1,
+              "new_password": p2},
         headers={"Authorization": f"Bearer {access_token}"},
     )
 

--- a/tests/v1/user/change_user_password_test.py
+++ b/tests/v1/user/change_user_password_test.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 client = TestClient(app)
 LOGIN_ENDPOINT = "api/v1/auth/login"
-CHANGE_PWD_ENDPOINT = "/api/v1/users/me/password"
+CHANGE_PWD_ENDPOINT = "/api/v1/auth/change-password"
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ def test_wrong_pwd(mock_db_session, mock_user_service):
 
     user_pwd_change = client.patch(
         CHANGE_PWD_ENDPOINT,
-        json={"old_password": "Testpassw23",
+        json={"old_password": "Testpassw23@",
               "new_password": "Ojobonandom@123"},
         headers={"Authorization": f"Bearer {access_token}"},
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fix currently fixes the error the endpoint change from /api/v1/users/me/password to /api/v1/auth/change-password. The fix also allows users that signed up with socials to be able to set a password.
​

## Description
This fix currently fixes the error the endpoint change from /api/v1/users/me/password to /api/v1/auth/change-password. The fix also allows users that signed up with socials to be able to set a password.

Users that signed up via socials usually do not have passwords set up, meaning they would always have to login using their social accounts, the fix here enables them set a password for their account at convenience, that way, they can then be ale to login with a password and email if they wished. The fix also improved on the allowed special characters for password and the exception of using null character or empty white space or non-printable characters as password.
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fix solves the need for users to be able to change their password with a wider availability of password-usable characters, and also allows users that sign up for the platform via socials to be able to set up a password.
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if any)
(user using old password as new password)
![password (user using old password as new password)](https://github.com/user-attachments/assets/e97d2430-33f8-40e3-87aa-0904ea3f1402)

user with no password who signed up with social entered values in old password)
![password (user with no password who signed up with social entered values in old password)](https://github.com/user-attachments/assets/4314aafa-bd42-45ef-b5ae-fb03cccbb1a5)

user who signed up with social setting up password
![password (user who signed up with social setting up password)](https://github.com/user-attachments/assets/9bc89875-7055-444c-83f8-945d4150a540)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


**Please let me know if there is any change i need to make. thank you.**
