### PR TITLE
fix: Fixed password update endpoint

### DIFF
--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -11,7 +11,7 @@ from api.v1.models import User
 from api.v1.schemas.user import Token
 from api.v1.schemas.user import LoginRequest, UserCreate, EmailRequest
 from api.v1.schemas.token import TokenRequest
-from api.v1.schemas.user import UserCreate, MagicLinkRequest
+from api.v1.schemas.user import UserCreate, MagicLinkRequest, ChangePasswordSchema
 from api.v1.services.organisation import organisation_service
 from api.v1.schemas.organisation import CreateUpdateOrganisation
 from api.db.database import get_db
@@ -300,3 +300,18 @@ async def verify_magic_link(token_schema: Token, db: Session = Depends(get_db)):
     )
 
     return response
+
+
+@auth.patch("/change-password", status_code=200)
+async def change_password(
+    schema: ChangePasswordSchema,
+    db: Session = Depends(get_db),
+    user: User = Depends(user_service.get_current_user),
+):
+    """Endpoint to change the user's password"""
+    user_service.change_password(new_password=schema.new_password,
+                                 user=user,
+                                 db=db,
+                                 old_password=schema.old_password)
+
+    return success_response(status_code=200, message="Password changed successfully")

--- a/api/v1/routes/user.py
+++ b/api/v1/routes/user.py
@@ -6,9 +6,7 @@ from sqlalchemy.orm import Session
 from api.utils.success_response import success_response
 from api.v1.models.user import User
 from api.v1.schemas.user import (
-    DeactivateUserSchema,
-    ChangePasswordSchema,
-    ChangePwdRet, AllUsersResponse, UserUpdate,
+    AllUsersResponse, UserUpdate,
     AdminCreateUserResponse, AdminCreateUser
 )
 from api.db.database import get_db
@@ -51,20 +49,6 @@ async def delete_account(request: Request, db: Session = Depends(get_db), curren
         status_code=200,
         message='User deleted successfully',
     )
-
-
-@user_router.patch("/me/password", status_code=200)
-async def change_password(
-    schema: ChangePasswordSchema,
-    db: Session = Depends(get_db),
-    user: User = Depends(user_service.get_current_user),
-):
-    """Endpoint to change the user's password"""
-
-    user_service.change_password(schema.old_password, schema.new_password, user, db)
-
-    return success_response(status_code=200, message="Password changed successfully")
-
 
 @user_router.patch("/",status_code=status.HTTP_200_OK)
 def update_current_user(

--- a/tests/v1/superadmin/test_admincreate.py
+++ b/tests/v1/superadmin/test_admincreate.py
@@ -25,7 +25,7 @@ data2 = {
 data3 = {
 
     "first_name": "Marvelu",
-    "last_name": "Ub",
+    "last_name": "Ubah",
     "password": "Doyinsola179@$",
     "email": "utibesolomon17@gmail.com"
     

--- a/tests/v1/user/change_user_password_test.py
+++ b/tests/v1/user/change_user_password_test.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 client = TestClient(app)
 LOGIN_ENDPOINT = "api/v1/auth/login"
-CHANGE_PWD_ENDPOINT = "/api/v1/users/me/password"
+CHANGE_PWD_ENDPOINT = "/api/v1/auth/change-password"
 
 
 @pytest.fixture
@@ -86,7 +86,7 @@ def test_wrong_pwd(mock_db_session, mock_user_service):
 
     user_pwd_change = client.patch(
         CHANGE_PWD_ENDPOINT,
-        json={"old_password": "Testpassw23",
+        json={"old_password": "Testpassw23@",
               "new_password": "Ojobonandom@123"},
         headers={"Authorization": f"Bearer {access_token}"},
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fix currently fixes the error the endpoint change from /api/v1/users/me/password to /api/v1/auth/change-password. The fix also allows users that signed up with socials to be able to set a password.
​

## Description
This fix currently fixes the error the endpoint change from /api/v1/users/me/password to /api/v1/auth/change-password. The fix also allows users that signed up with socials to be able to set a password.

Users that signed up via socials usually do not have passwords set up, meaning they would always have to login using their social accounts, the fix here enables them set a password for their account at convenience, that way, they can then be ale to login with a password and email if they wished. The fix also improved on the allowed special characters for password and the exception of using null character or empty white space or non-printable characters as password.
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fix solves the need for users to be able to change their password with a wider availability of password-usable characters, and also allows users that sign up for the platform via socials to be able to set up a password.
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if any)
(user using old password as new password)
![password (user using old password as new password)](https://github.com/user-attachments/assets/93af1853-0f41-490e-b332-70379ccb73a9)




user with no password who signed up with social entered values in old password)
![password (user with no password who signed up with social entered values in old password)](https://github.com/user-attachments/assets/c189ac8c-2ab9-4789-bb42-f56eacc43071)



user who signed up with social setting up password
![password (user who signed up with social setting up password)](https://github.com/user-attachments/assets/d570828d-a0de-4176-834f-8fad91e351d2)




## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


**Please let me know if there is any change i need to make. thank you.**
