### PR TITLE
fix: removed orgid from being passed to ContactUs table

### DIFF
--- a/api/v1/services/contact_us.py
+++ b/api/v1/services/contact_us.py
@@ -29,7 +29,7 @@ class ContactUsService(Service):
             email=getattr(data, self.adabtingMapper["email"]),
             title=getattr(data, self.adabtingMapper["title"]),
             message=getattr(data, self.adabtingMapper["message"]),
-            org_id=getattr(data, self.adabtingMapper["org_id"])
+            # org_id=getattr(data, self.adabtingMapper["org_id"])
         )
         db.add(contact_message)
         db.commit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description

<!--- Describe your changes in detail -->
This update removes the dependency on the org_id field when submitting data to the ContactUs table. The org_id is no longer passed during the form submission process, allowing users to submit contact requests without needing an associated organization ID.


​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required to make the contact form usable to users who do not have an associated organization. The submission process initially depended on the org_id field, preventing unauthenticated users to submit contact requests
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

​

## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/user-attachments/assets/a451215c-2f16-4067-9da6-c4bc181819a7)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
