### PR TITLE
fix: Fixed password update http method from PATCH to PUT

### DIFF
--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -344,7 +344,7 @@ async def verify_magic_link(token_schema: Token, db: Session = Depends(get_db)):
     return response
 
 
-@auth.patch("/change-password", status_code=200)
+@auth.put("/password", status_code=200)
 async def change_password(
     schema: ChangePasswordSchema,
     db: Session = Depends(get_db),

--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -246,6 +246,13 @@ class ChangePasswordSchema(BaseModel):
                           strip_whitespace=True)
     ]
 
+    confirm_new_password: Annotated[
+        str,
+        StringConstraints(min_length=8,
+                          max_length=64,
+                          strip_whitespace=True)
+    ]
+
     @model_validator(mode='before')
     @classmethod
     def validate_password(cls, values: dict):
@@ -254,6 +261,7 @@ class ChangePasswordSchema(BaseModel):
         """
         old_password = values.get('old_password')
         new_password = values.get('new_password')
+        confirm_new_password = values.get("confirm_new_password")
 
         if (old_password and old_password.strip() == '') or old_password == '':
             values['old_password'] = None
@@ -277,6 +285,9 @@ class ChangePasswordSchema(BaseModel):
             raise ValueError("New password must include at least one digit")
         if not any(c in ['!','@','#','$','%','&','*','?','_','-'] for c in new_password):
             raise ValueError("New password must include at least one special character")
+        
+        if confirm_new_password != new_password:
+            raise ValueError("New Password and Confirm New Password must match")
         
         return values
 

--- a/tests/v1/user/change_user_password_test.py
+++ b/tests/v1/user/change_user_password_test.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 client = TestClient(app)
 LOGIN_ENDPOINT = "api/v1/auth/login"
-CHANGE_PWD_ENDPOINT = "/api/v1/auth/change-password"
+CHANGE_PWD_ENDPOINT = "/api/v1/auth/password"
 
 
 @pytest.fixture
@@ -64,10 +64,11 @@ def test_autheniticated_user(mock_db_session, mock_user_service):
     )
     access_token = login.json()["access_token"]
 
-    user_pwd_change = client.patch(
+    user_pwd_change = client.put(
         CHANGE_PWD_ENDPOINT,
         json={"old_password": "Testpassword@123",
-              "new_password": "Ojobonandom@123"},
+              "new_password": "Ojobonandom@123",
+              "confirm_new_password": "Ojobonandom@123"},
     )
     assert user_pwd_change.status_code == 401
     assert user_pwd_change.json()["message"] == "Not authenticated"
@@ -84,10 +85,11 @@ def test_wrong_pwd(mock_db_session, mock_user_service):
     )
     access_token = login.json()["access_token"]
 
-    user_pwd_change = client.patch(
+    user_pwd_change = client.put(
         CHANGE_PWD_ENDPOINT,
         json={"old_password": "Testpassw23@",
-              "new_password": "Ojobonandom@123"},
+              "new_password": "Ojobonandom@123",
+              "confirm_new_password": "Ojobonandom@123"},
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert user_pwd_change.status_code == 400
@@ -105,10 +107,11 @@ def test_user_password(mock_db_session, mock_user_service):
     )
     access_token = login.json()["access_token"]
 
-    user_pwd_change = client.patch(
+    user_pwd_change = client.put(
         CHANGE_PWD_ENDPOINT,
         json={"old_password": "Testpassword@123",
-              "new_password": "Ojobonandom@123"},
+              "new_password": "Ojobonandom@123",
+              "confirm_new_password": "Ojobonandom@123"},
         headers={"Authorization": f"Bearer {access_token}"},
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request is intended to change the http method of password change from patch to put, and rename the endpoint from /api/v1/auth/change-password to /api/v1/auth/password, and add a new field: confirm_new_pasword.
​

## Description
This pull request is intended to change the http method of password change from patch to put, and rename the endpoint from /api/v1/auth/change-password to /api/v1/auth/password, and add a new field: confirm_new_pasword.
<!--- Describe your changes in detail -->

​

## Related Issue (Link to issue ticket)
[modify password update endpoint](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/923)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

​This has been tested with pytest and postman

## Screenshots (if appropriate - Postman, etc):

![bugfix password not a match main](https://github.com/user-attachments/assets/c66be22b-a84e-411d-b67d-3f91c8bb312b)

![bugfix password old and new cannot be same](https://github.com/user-attachments/assets/0e30513d-bcb7-446b-8ac5-2fa8ccb16262)

![bugfix password changed successfully](https://github.com/user-attachments/assets/92b9ea38-f9fc-4bfb-a35e-ea1fd83754fe)


​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


