### PR TITLE
enhancement: update billing plan endpoints docs to show sample return data

### DIFF
--- a/api/v1/routes/billing_plan.py
+++ b/api/v1/routes/billing_plan.py
@@ -10,12 +10,15 @@ from api.v1.models.user import User
 from api.v1.services.billing_plan import billing_plan_service
 from api.db.database import get_db
 from api.v1.services.user import user_service
-from api.v1.schemas.plans import CreateSubscriptionPlan
+from api.v1.schemas.plans import (
+    CreateBillingPlanSchema, CreateBillingPlanResponse, GetBillingPlanListResponse
+)
+
 
 bill_plan = APIRouter(prefix="/organisations", tags=["Billing-Plan"])
 
 
-@bill_plan.get("/{organisation_id}/billing-plans", response_model=success_response)
+@bill_plan.get("/{organisation_id}/billing-plans", response_model=GetBillingPlanListResponse)
 async def retrieve_all_billing_plans(
     organisation_id: str, db: Session = Depends(get_db)
 ):
@@ -34,10 +37,10 @@ async def retrieve_all_billing_plans(
     )
 
 
-@bill_plan.post("/billing-plans", response_model=success_response)
+@bill_plan.post("/billing-plans", response_model=CreateBillingPlanResponse)
 async def create_new_billing_plan(
-    request: CreateSubscriptionPlan,
-    current_user: User = Depends(user_service.get_current_super_admin),
+    request: CreateBillingPlanSchema,
+    _: User = Depends(user_service.get_current_super_admin),
     db: Session = Depends(get_db),
 ):
     """
@@ -53,11 +56,11 @@ async def create_new_billing_plan(
     )
 
 
-@bill_plan.patch("/billing-plans/{billing_plan_id}", response_model=success_response)
+@bill_plan.patch("/billing-plans/{billing_plan_id}", response_model=CreateBillingPlanResponse)
 async def update_a_billing_plan(
     billing_plan_id: str,
-    request: CreateSubscriptionPlan,
-    current_user: User = Depends(user_service.get_current_super_admin),
+    request: CreateBillingPlanSchema,
+    _: User = Depends(user_service.get_current_super_admin),
     db: Session = Depends(get_db),
 ):
     """
@@ -76,7 +79,7 @@ async def update_a_billing_plan(
 @bill_plan.delete("/billing-plans/{billing_plan_id}", response_model=success_response)
 async def delete_a_billing_plan(
     billing_plan_id: str,
-    current_user: User = Depends(user_service.get_current_super_admin),
+    _: User = Depends(user_service.get_current_super_admin),
     db: Session = Depends(get_db),
 ):
     """
@@ -91,11 +94,11 @@ async def delete_a_billing_plan(
     )
 
 
-@bill_plan.get('/billing-plans/{billing_plan_id}', response_model=success_response)
+@bill_plan.get('/billing-plans/{billing_plan_id}', response_model=CreateBillingPlanResponse)
 async def retrieve_single_billing_plans(
     billing_plan_id: str,
     db: Session = Depends(get_db),
-    current_user: User = Depends(user_service.get_current_user)
+    _: User = Depends(user_service.get_current_user)
 ):
     """
     Endpoint to get single billing plan by id

--- a/api/v1/schemas/base_schema.py
+++ b/api/v1/schemas/base_schema.py
@@ -1,0 +1,16 @@
+from typing import List
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ResponseBase(BaseModel):
+    status_code: int = 200
+    success: bool
+    message: str
+
+
+class PaginationBase(BaseModel):
+    limit: int
+    offset: int
+    pages: int
+    total_items: int

--- a/api/v1/schemas/plans.py
+++ b/api/v1/schemas/plans.py
@@ -1,8 +1,11 @@
 from pydantic import BaseModel, validator
 from typing import List, Optional
+from datetime import datetime
+
+from api.v1.schemas.base_schema import ResponseBase
 
 
-class CreateSubscriptionPlan(BaseModel):
+class CreateBillingPlanSchema(BaseModel):
     name: str
     description: Optional[str] = None
     price: int
@@ -26,22 +29,22 @@ class CreateSubscriptionPlan(BaseModel):
         return v
 
 
-class SubscriptionPlanResponse(CreateSubscriptionPlan):
+class CreateBillingPlanReturnData(CreateBillingPlanSchema):
     id: str
+    created_at: datetime
+    updated_at: datetime
 
     class Config:
         from_attributes = True
 
 
-class BillingPlanSchema(BaseModel):
-    id: str
-    organisation_id: str
-    name: str
-    price: float
-    currency: str
-    duration: str
-    description: Optional[str] = None
-    features: List[str]
+class CreateBillingPlanResponse(ResponseBase):
+    data: CreateBillingPlanReturnData
 
-    class Config:
-        orm_mode = True
+
+class GetBillingPlanData(BaseModel):
+    billing_plans: List[CreateBillingPlanReturnData]
+
+
+class GetBillingPlanListResponse(ResponseBase):
+    data: GetBillingPlanData

--- a/api/v1/schemas/plans.py
+++ b/api/v1/schemas/plans.py
@@ -43,7 +43,7 @@ class CreateBillingPlanResponse(ResponseBase):
 
 
 class GetBillingPlanData(BaseModel):
-    billing_plans: List[CreateBillingPlanReturnData]
+    plans: List[CreateBillingPlanReturnData]
 
 
 class GetBillingPlanListResponse(ResponseBase):

--- a/api/v1/services/billing_plan.py
+++ b/api/v1/services/billing_plan.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from api.v1.models.billing_plan import BillingPlan
 from typing import Any, Optional
 from api.core.base.services import Service
-from api.v1.schemas.plans import CreateSubscriptionPlan
+from api.v1.schemas.plans import CreateBillingPlanSchema
 from api.utils.db_validators import check_model_existence
 from fastapi import HTTPException, status
 
@@ -11,7 +11,7 @@ from fastapi import HTTPException, status
 class BillingPlanService(Service):
     """Product service functionality"""
 
-    def create(self, db: Session, request: CreateSubscriptionPlan):
+    def create(self, db: Session, request: CreateBillingPlanSchema):
         """
         Create and return a new billing plan, ensuring a plan name can only exist 
         once for each 'monthly' and 'yearly' duration, and cannot be created 


### PR DESCRIPTION
 ## Description
Update billing plan endpoints docs to show samples of expected data so frontend developers can easily integrate with the backend. Endpoint docs updated include:
- /api/v1/organisations/{organisation_id}/billing-plans
- /api/v1/organisations/billing-plans
- /api/v1/organisations/billing-plans/{billing_plan_id}
- /api/v1/organisations/billing-plans/{billing_plan_id}
 
## Related Issue
[[FIX]: Add Expected Data Samples To Docs For All Billing Plan Endpoints #941](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/941)


 ## Motivation and Context
Frontend developers and others viewing the backend docs should be able to know exactly what to expect from each endpoint.
 

 ## How Has This Been Tested?
 * **Unit Tests:** Added tests to validate successful and failed requests as expected.
* **Test Environment:** Mocked database; to avoid interference with the production environment.


## Screenshots:
### Before The Update
<img width="960" alt="boilerplate get all billing plan return value" src="https://github.com/user-attachments/assets/e6583d75-d4fc-4e6d-bf5d-7db9a3907d48">
<img width="960" alt="boilerplate post billing plan return value" src="https://github.com/user-attachments/assets/2f7d29e2-2c4c-432a-ab82-e7b7d304fd61">


### After The Update
<img width="960" alt="updated billing plan schema all" src="https://github.com/user-attachments/assets/3150686f-6edd-4eec-889d-ad43dad0e19a">
<img width="960" alt="updated billing plan schema single" src="https://github.com/user-attachments/assets/a218a8ab-98a4-436b-b183-b4fd795e3836">



## Types of changes
* [x]  Bug fix (non-breaking change which adds functionality)
 

 ## Checklist:
 * [x]  My code follows the code style of this project.
 * [x]  My change requires a change to the documentation.
 * [x]  I have updated the documentation accordingly.
 * [x]  I have read the **CONTRIBUTING** document.
 * [x]  I have added tests to cover my changes.
 * [x]  All new and existing tests passed.