### PR TITLE
feat: delete blog like

### DIFF
--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -311,7 +311,7 @@ async def update_blog_comment(
 
 @blog.delete("/likes/{blog_like_id}", 
              status_code=status.HTTP_204_NO_CONTENT)
-def delete_blog_like(
+async def delete_blog_like(
     blog_like_id: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(user_service.get_current_user),
@@ -326,4 +326,4 @@ def delete_blog_like(
     blog_like_service = BlogLikeService(db)
 
     # delete blog like
-    blog_like_service.delete(blog_like_id, current_user.id)
+    return blog_like_service.delete(blog_like_id, current_user.id)

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -10,7 +10,7 @@ from api.db.database import get_db
 from api.utils.pagination import paginated_response
 from api.utils.success_response import success_response
 from api.v1.models.user import User
-from api.v1.models.blog import Blog, BlogDislike, BlogLike
+from api.v1.models.blog import Blog
 from api.v1.schemas.blog import (
     BlogCreate,
     BlogPostResponse,
@@ -20,7 +20,7 @@ from api.v1.schemas.blog import (
     CommentRequest,
     CommentUpdateResponseModel
 )
-from api.v1.services.blog import BlogService, BlogLikeService, BlogDislikeService
+from api.v1.services.blog import BlogService, BlogLikeService
 from api.v1.services.user import user_service
 from api.v1.schemas.comment import CommentCreate, CommentSuccessResponse
 from api.v1.services.comment import comment_service

--- a/api/v1/services/blog.py
+++ b/api/v1/services/blog.py
@@ -147,13 +147,13 @@ class BlogService:
             existing_dislike = self.fetch_blog_dislike(blog.id, user.id)
             if existing_dislike:
                 # delete, but do not commit yet. Allow everything 
-                # to be commited when operation like created
+                # to be commited after the actual like is created
                 self.db.delete(existing_dislike)
-        if creating == "dislike":
+        elif creating == "dislike":
             existing_like = self.fetch_blog_like(blog.id, user.id)
             if existing_like:
                 # delete, but do not commit yet. Allow everything 
-                # to be commited when operation dislike created
+                # to be commited after the actual dislike is created
                 self.db.delete(existing_like)
         else:
             raise HTTPException(
@@ -262,29 +262,4 @@ class BlogLikeService:
             )
 
         self.db.delete(blog_like)
-        self.db.commit()
-
-
-class BlogDislikeService:
-    """BlogDislike service functionality"""
-
-    def __init__(self, db: Session):
-        self.db = db
-
-    def fetch(self, blog_dislike_id: str):
-        """Fetch a blog dislike by its ID"""
-        return check_model_existence(self.db, BlogLike, blog_dislike_id)
-
-    def delete(self, blog_dislike_id: str, user_id: str):
-        """Delete blog dislike"""
-        blog_dislike = self.fetch(blog_dislike_id)
-
-        # check that current user owns the blog like
-        if blog_dislike.user_id != user_id:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Insufficient permission"
-            )
-
-        self.db.delete(blog_dislike)
         self.db.commit()

--- a/tests/v1/blog/test_delete_blog_like.py
+++ b/tests/v1/blog/test_delete_blog_like.py
@@ -4,9 +4,9 @@ from uuid_extensions import uuid7
 from sqlalchemy.orm import Session
 from api.db.database import get_db
 from datetime import datetime, timezone
+from api.v1.models import User, BlogLike
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
-from api.v1.models import User, BlogDislike
 from api.v1.services.user import user_service
 
 client = TestClient(app)
@@ -58,7 +58,7 @@ def another_user():
 
 @pytest.fixture
 def test_blog_like(test_user):
-    return BlogDislike(
+    return BlogLike(
             id=str(uuid7()),
             user_id=test_user.id,
             blog_id=str(uuid7()),

--- a/tests/v1/blog/test_delete_blog_like.py
+++ b/tests/v1/blog/test_delete_blog_like.py
@@ -1,0 +1,144 @@
+import pytest
+from main import app
+from uuid_extensions import uuid7
+from sqlalchemy.orm import Session
+from api.db.database import get_db
+from datetime import datetime, timezone
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from api.v1.models import User, BlogDislike
+from api.v1.services.user import user_service
+
+client = TestClient(app)
+
+# Mock database
+@pytest.fixture
+def mock_db_session(mocker):
+    db_session_mock = mocker.MagicMock(spec=Session)
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    return db_session_mock
+
+
+@pytest.fixture
+def mock_user_service():
+    with patch("api.v1.services.user.user_service", autospec=True) as user_service_mock:
+        yield user_service_mock
+
+
+@pytest.fixture
+def mock_blog_service():
+    with patch("api.v1.services.blog.BlogService", autospec=True) as blog_service_mock:
+        yield blog_service_mock
+
+
+# Test User
+@pytest.fixture
+def test_user():
+    return User(
+        id=str(uuid7()),
+        email="testuser@gmail.com",
+        password="hashedpassword",
+        first_name="test",
+        last_name="user",
+        is_active=True,
+    )
+
+
+# Another User
+@pytest.fixture
+def another_user():
+    return User(
+        id=str(uuid7()),
+        email="anotheruser@gmail.com",
+        password="hashedpassword",
+        first_name="another",
+        last_name="user",
+        is_active=True,
+    )
+
+@pytest.fixture
+def test_blog_like(test_user):
+    return BlogDislike(
+            id=str(uuid7()),
+            user_id=test_user.id,
+            blog_id=str(uuid7()),
+            ip_address="192.168.1.0",
+            created_at=datetime.now(tz=timezone.utc)
+        )
+
+@pytest.fixture
+def access_token_user(test_user):
+    return user_service.create_access_token(user_id=test_user.id)
+
+@pytest.fixture
+def access_token_another(another_user):
+    return user_service.create_access_token(user_id=another_user.id)
+
+
+def make_request(blog_like_id, token):
+    return client.delete(
+        f"/api/v1/blogs/likes/{blog_like_id}",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+
+
+# test for successful delete
+@patch("api.v1.services.blog.BlogLikeService.fetch")
+def test_successful_delete_bloglike(
+    mock_fetch_blog_like,
+    mock_db_session, 
+    test_user,
+    test_blog_like,
+    access_token_user
+):
+    # mock current-user AND blog-like
+    mock_db_session.query().filter().first.return_value = test_user
+    mock_fetch_blog_like.return_value = test_blog_like
+
+    resp = make_request(test_blog_like.id, access_token_user)
+    assert resp.status_code == 204
+
+
+# Test for wrong blog like id
+def test_wrong_blog_like_id(
+    # mock_fetch_blog_like,
+    mock_db_session, 
+    test_user,
+    access_token_user,
+):
+    mock_db_session.query().filter().first.return_value = test_user
+    mock_db_session.get.return_value = None
+
+    ### TEST REQUEST WITH WRONG blog_like_id ###
+    resp = make_request(str(uuid7()), access_token_user)
+    assert resp.status_code == 404
+    assert resp.json()['message'] == "BlogLike does not exist"
+
+
+# Test for unauthenticated user
+def test_wrong_auth_token(
+    mock_db_session,
+    test_blog_like
+):
+    mock_user_service.get_current_user = None
+
+    ### TEST ATTEMPT WITH INVALID AUTH ###
+    resp = make_request(test_blog_like.id, None)
+    assert resp.status_code == 401
+    assert resp.json()['message'] == 'Could not validate credentials'
+
+
+# Test for wrong owner request
+def test_wrong_owner_request(
+    mock_db_session,
+    test_blog_like,
+    another_user,
+    access_token_another
+):
+    mock_user_service.get_current_user = another_user
+    mock_db_session.get.return_value = test_blog_like
+
+    ### TEST ATTEMPT BY NON OWNER ###
+    resp = make_request(test_blog_like.id, access_token_another)
+    assert resp.status_code == 401
+    assert resp.json()['message'] == 'Insufficient permission'


### PR DESCRIPTION
## Description:
An endpoint to enable users who previously `liked` a blog post to remove the `like`.

## Related Issue:

[[FEAT]: Endpoint To Delete Blog Like #965](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/965)

## Motivation and Context
Readers should be able to remove **like** from a particular post after adding one, if they posted it in error or just changed their mind.

## How Has This Been Tested?
* **Unit Tests:** Added tests to validate successful and failed requests as expected.
* **Test Environment:** Mocked database; to avoid interference with the production environment.
* **Postman:** Validation test has also been run on postman API tester, with screenshots attached below.


## Screenshots:
### Delete Blog Like Success
<img width="960" alt="delete blog like success" src="https://github.com/user-attachments/assets/ad763531-0597-4ba7-8108-4753acfb3ea9">


### Non Owner Request
<img width="960" alt="delete blog like not owner" src="https://github.com/user-attachments/assets/f8b36ecc-699c-4d94-94fd-6ee37c23fa86">


### Blog Like Not Available
<img width="960" alt="delete blog like not found" src="https://github.com/user-attachments/assets/b8883143-e3d9-41a9-a7ea-b2e2699215a9">


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
 
- [x]  My code follows the code style of this project.
- [x]  I have updated the documentation accordingly.
- [x]  I have read the CONTRIBUTING document.
- [x]  I have added tests to cover my changes.
- [x]  All new and existing tests passed.
***

## Added Fix:
Enable `/api/v1/blogs/{blog_id}/like` endpoint  to automatically remove existing `dislike` by the `current_user` before creating new `like`, and vice versa with the `/api/v1/blogs/{blog_id}/dislike` endpoint.

This is important if a user clicks the **like button** after already clicking the dislike button without first removing the dislike. Otherwise, the database will have unintended records of both **like** and **dislike** for the same user on the same blog