### PR TITLE
Add Environment Variable Validation on Project Startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 #.idea/
 
 alembic/versions
+.idea/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,145 @@ FastAPI boilerplate
     source /path/to/venv/bin/activate`
 ```
 3. Install project dependencies `pip install -r requirements.txt`
-4. Create a .env file by copying the .env.sample file
+4. Create a .env.template file by running the command `python create_env_template.py`. This generates predefined environment variables in the `env_validator.py` file.
+5. create a `.env` file.
+6. Copy the contents of `.env.template` file into the `.env` file.
 `cp .env.sample .env`
-
-5. Start server.
+7. Key in your environment variable details in the `.env` file.
+7. Start server.
  ```sh
  python main.py
 ```
+
+## **Creating Environment Variables**
+To create environment variables based on the env_validator.py, follow these steps:
+1. Add your new environment variable to the category you wish, for example:
+   ```
+         "Core Settings": [
+            "SECRET_KEY", "ALGORITHM", "ACCESS_TOKEN_EXPIRE_MINUTES", "JWT_REFRESH_EXPIRY",
+                "APP_URL", "PYTHON_ENV", "MY_NEW_VARIABLE" // Added MY_NEW_VARIABLE to core settings category
+        ],
+   ```
+2. Modify env_validator.py to Add a New Variable:
+   Open the env_validator.py file and add your new environment variable to the required_vars dictionary. For example, to add a new variable NEW_VARIABLE:
+    ```
+            "NEW_VARIABLE": {
+            "required": True,
+            "description": "Description of what this variable does",
+            "type": "int",  # if applicable
+            "min_length": 8,  # if applicable
+            "allowed_values": [12345678, 87654321]  # Example integer values with at least 8 digits
+        }
+    ```
+3. Generate a new template:
+    Run the `create_env_template.py` script to generate a new `.env.template` file:
+   ```shell
+      python create_env_template.py  
+     ```
+   This will create a .env.template file with all required environment variables, including the new one you added.
+
+4. Update your `.env` File:
+   Open your .env file and add the new variable with its value:
+    ```
+        # Description of what this variable does (Required)
+         NEW_VARIABLE=12345678
+   ```
+5. Validate Environment Variables:
+   Ensure that the environment variables are validated at the application startup by importing and running the validator `main.py` file:
+    This process ensures that the new environment variable is added to the validator and included in the generated .env.template and .env files.
+
+### Add New Category for Environment variables
+
+1. **Modify the `EnvValidator` class to include the new category:**
+
+   Add the new category to the `CATEGORIES` dictionary in the `EnvValidator` class. For example, to add a new category called "Logging Settings":
+
+   ```python
+   class EnvValidator:
+       # Class variable to define variable categories for template generation
+       CATEGORIES = {
+           "Core Settings": [
+               "SECRET_KEY", "ALGORITHM", "ACCESS_TOKEN_EXPIRE_MINUTES", "JWT_REFRESH_EXPIRY",
+               "APP_URL", "PYTHON_ENV", "MY_NEW_VARIABLE"
+           ],
+           "Database Settings": [
+               "DB_TYPE", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_HOST", "DB_PORT",
+               "MYSQL_DRIVER", "DB_URL"
+           ],
+           "OAuth Settings": [
+               "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "FRONTEND_URL"
+           ],
+           "Email Settings": [
+               "MAIL_USERNAME", "MAIL_PASSWORD", "MAIL_FROM", "MAIL_PORT", "MAIL_SERVER",
+               "MAILJET_API_KEY", "MAILJET_API_SECRET"
+           ],
+           "SMS Settings": [
+               "TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_PHONE_NUMBER"
+           ],
+           "Payment Settings": [
+               "FLUTTERWAVE_SECRET", "PAYSTACK_SECRET", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"
+           ],
+           "Testing": [
+               "TESTING"
+           ],
+           "Logging Settings": [  # New category
+               "LOG_LEVEL", "LOG_FILE_PATH"
+           ]
+       }
+   ```
+
+2. **Add the new environment variables to the `required_vars` dictionary:**
+
+   Define the new environment variables under the `required_vars` dictionary in the `EnvValidator` class. For example:
+
+   ```python
+   class EnvValidator:
+       def __init__(self):
+           self.required_vars = {
+               # Core settings
+               "SECRET_KEY": {"required": True, "min_length": 16, "description": "Secret key for cryptographic signing"},
+               "ALGORITHM": {"required": True, "default": "HS256", "description": "JWT algorithm"},
+               "ACCESS_TOKEN_EXPIRE_MINUTES": {"required": True, "type": "int", "default": "3000",
+                                               "description": "Access token expiry time in minutes"},
+               "JWT_REFRESH_EXPIRY": {"required": True, "type": "int", "default": "7",
+                                      "description": "Refresh token expiry time in days"},
+               "MY_NEW_VARIABLE": {
+                   "required": True,  # or False
+                   "description": "Description of what this variable does",
+                   # Optional: add any other validation rules
+                   "default": "12345678",  # if applicable
+                   "type": "int",  # if applicable
+                   "min_length": 8,  # if applicable
+                   "allowed_values": ["12345678", "87654321"]
+               },
+               # Logging settings
+               "LOG_LEVEL": {"required": True, "allowed_values": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                             "default": "INFO", "description": "Logging level"},
+               "LOG_FILE_PATH": {"required": False, "description": "Path to the log file"}
+           }
+   ```
+
+3. **Generate a new template:**
+
+   Run the `create_env_template.py` script to generate a new `.env.template` file:
+
+   ```sh
+   python create_env_template.py
+   ```
+
+   This will create a `.env.template` file with all required environment variables, including the new ones you added.
+
+4. **Update your `.env` file:**
+
+   Open your `.env` file and add the new variables with their values:
+
+   ```dotenv
+   # Logging Settings
+   LOG_LEVEL=INFO
+   LOG_FILE_PATH=/path/to/logfile.log
+   ```
+
+This process ensures that the new category and its environment variables are added to the validator and included in the generated `.env.template` and `.env` files.
 
 ## **DATABASE TEST SETUP**
 

--- a/api/utils/settings.py
+++ b/api/utils/settings.py
@@ -9,7 +9,7 @@ BASE_DIR = Path(__file__).resolve().parent
 
 class Settings(BaseSettings):
     """ Class to hold application's config values."""
-    
+
     SECRET_KEY: str = config("SECRET_KEY")
     ALGORITHM: str = config("ALGORITHM")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = config("ACCESS_TOKEN_EXPIRE_MINUTES")

--- a/create_env_template.py
+++ b/create_env_template.py
@@ -1,0 +1,10 @@
+"""
+Generate a template .env file with all required environment variables.
+
+This script creates a .env.template file that includes all required and
+optional environment variables with descriptions.
+"""
+from env_validator import generate_env_template
+
+if __name__ == "__main__":
+    generate_env_template()

--- a/env_validator.py
+++ b/env_validator.py
@@ -15,7 +15,7 @@ class EnvValidator:
     CATEGORIES = {
         "Core Settings": [
             "SECRET_KEY", "ALGORITHM", "ACCESS_TOKEN_EXPIRE_MINUTES", "JWT_REFRESH_EXPIRY",
-            "APP_URL", "PYTHON_ENV"
+            "APP_URL", "PYTHON_ENV", "MY_NEW_VARIABLE"
         ],
         "Database Settings": [
             "DB_TYPE", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_HOST", "DB_PORT",
@@ -48,6 +48,16 @@ class EnvValidator:
                                             "description": "Access token expiry time in minutes"},
             "JWT_REFRESH_EXPIRY": {"required": True, "type": "int", "default": "7",
                                    "description": "Refresh token expiry time in days"},
+            "MY_NEW_VARIABLE": {
+                "required": True,  # or False
+                "description": "Description of what this variable does",
+                # Optional: add any other validation rules
+                "default": "12345678",  # if applicable
+                "type": "int",  # if applicable
+                "min_length": 8,  # if applicable
+                "allowed_values": ["12345678", "87654321"]
+            },
+
 
             # Database settings
             "DB_TYPE": {"required": True, "allowed_values": ["postgresql", "mysql", "sqlite"], "default": "postgresql",

--- a/env_validator.py
+++ b/env_validator.py
@@ -1,0 +1,272 @@
+"""
+Environment Variable Validator
+
+This module provides validation for environment variables without modifying
+existing code in main.py or settings.py. It should be imported at the beginning
+of the application startup process.
+"""
+import os
+import sys
+from typing import Dict, List, Any, Optional, Tuple
+
+
+class EnvValidator:
+    # Class variable to define variable categories for template generation
+    CATEGORIES = {
+        "Core Settings": [
+            "SECRET_KEY", "ALGORITHM", "ACCESS_TOKEN_EXPIRE_MINUTES", "JWT_REFRESH_EXPIRY",
+            "APP_URL", "PYTHON_ENV"
+        ],
+        "Database Settings": [
+            "DB_TYPE", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_HOST", "DB_PORT",
+            "MYSQL_DRIVER", "DB_URL"
+        ],
+        "OAuth Settings": [
+            "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", "FRONTEND_URL"
+        ],
+        "Email Settings": [
+            "MAIL_USERNAME", "MAIL_PASSWORD", "MAIL_FROM", "MAIL_PORT", "MAIL_SERVER",
+            "MAILJET_API_KEY", "MAILJET_API_SECRET"
+        ],
+        "SMS Settings": [
+            "TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_PHONE_NUMBER"
+        ],
+        "Payment Settings": [
+            "FLUTTERWAVE_SECRET", "PAYSTACK_SECRET", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"
+        ],
+        "Testing": [
+            "TESTING"
+        ]
+    }
+
+    def __init__(self):
+        self.required_vars = {
+            # Core settings
+            "SECRET_KEY": {"required": True, "min_length": 16, "description": "Secret key for cryptographic signing"},
+            "ALGORITHM": {"required": True, "default": "HS256", "description": "JWT algorithm"},
+            "ACCESS_TOKEN_EXPIRE_MINUTES": {"required": True, "type": "int", "default": "3000",
+                                            "description": "Access token expiry time in minutes"},
+            "JWT_REFRESH_EXPIRY": {"required": True, "type": "int", "default": "7",
+                                   "description": "Refresh token expiry time in days"},
+
+            # Database settings
+            "DB_TYPE": {"required": True, "allowed_values": ["postgresql", "mysql", "sqlite"], "default": "postgresql",
+                        "description": "Database type"},
+            "DB_NAME": {"required": True, "description": "Database name"},
+            "DB_USER": {"required": True, "description": "Database username"},
+            "DB_PASSWORD": {"required": True, "description": "Database password"},
+            "DB_HOST": {"required": True, "description": "Database host"},
+            "DB_PORT": {"required": True, "type": "int", "default": "5432", "description": "Database port"},
+
+            # OAuth settings
+            "GOOGLE_CLIENT_ID": {"required": False, "description": "Google OAuth client ID"},
+            "GOOGLE_CLIENT_SECRET": {"required": False, "description": "Google OAuth client secret"},
+            "FRONTEND_URL": {"required": False, "default": "http://127.0.0.1:3000/login-success",
+                             "description": "Frontend URL for OAuth redirects"},
+
+            # Email settings
+            "MAIL_USERNAME": {"required": True, "description": "SMTP username"},
+            "MAIL_PASSWORD": {"required": True, "description": "SMTP password"},
+            "MAIL_FROM": {"required": True, "description": "Sender email address"},
+            "MAIL_PORT": {"required": True, "type": "int", "default": "465", "description": "SMTP port"},
+            "MAIL_SERVER": {"required": True, "description": "SMTP server"},
+
+            # SMS settings
+            "TWILIO_ACCOUNT_SID": {"required": False, "description": "Twilio account SID"},
+            "TWILIO_AUTH_TOKEN": {"required": False, "description": "Twilio authentication token"},
+            "TWILIO_PHONE_NUMBER": {"required": False, "description": "Twilio phone number"},
+
+            # Payment settings
+            "FLUTTERWAVE_SECRET": {"required": False, "description": "Flutterwave API secret key"},
+            "PAYSTACK_SECRET": {"required": False, "description": "Paystack API secret key"},
+            "STRIPE_SECRET_KEY": {"required": False, "description": "Stripe secret key"},
+            "STRIPE_WEBHOOK_SECRET": {"required": False, "description": "Stripe webhook secret"},
+
+            # MailJet settings
+            "MAILJET_API_KEY": {"required": False, "description": "MailJet API key"},
+            "MAILJET_API_SECRET": {"required": False, "description": "MailJet API secret"},
+
+            # Environment settings
+            "PYTHON_ENV": {"required": False, "allowed_values": ["dev", "test", "prod"], "default": "dev",
+                           "description": "Application environment"},
+        }
+
+        # Keep track of validation issues
+        self.validation_errors = []
+        self.warnings = []
+
+    def validate_all(self) -> bool:
+        """
+        Validates all required environment variables.
+
+        Returns:
+            bool: True if all required variables are valid, False otherwise
+        """
+        self.validation_errors = []
+        self.warnings = []
+
+        # Check all required environment variables
+        for var_name, requirements in self.required_vars.items():
+            value = os.environ.get(var_name)
+
+            # Skip non-required variables that aren't set
+            if not requirements.get("required", False) and value is None:
+                continue
+
+            # For required variables, ensure they are set
+            if requirements.get("required", False) and (value is None or value.strip() == ""):
+                # Check if there's a default value
+                if "default" in requirements:
+                    self.warnings.append(f"{var_name} is using default value: {requirements['default']}")
+                else:
+                    self.validation_errors.append(f"{var_name} is required but not set")
+                    continue
+
+            # Only validate if the value is actually set
+            if value is not None and value.strip() != "":
+                # Type validation
+                if requirements.get("type") == "int":
+                    try:
+                        int(value)
+                    except ValueError:
+                        self.validation_errors.append(f"{var_name} must be an integer")
+
+                # Length validation
+                if "min_length" in requirements and len(value) < requirements["min_length"]:
+                    self.validation_errors.append(
+                        f"{var_name} must be at least {requirements['min_length']} characters long"
+                    )
+
+                # Value validation
+                if "allowed_values" in requirements and value.lower() not in requirements["allowed_values"]:
+                    self.validation_errors.append(
+                        f"{var_name} must be one of: {', '.join(requirements['allowed_values'])}"
+                    )
+
+        return len(self.validation_errors) == 0
+
+    def print_validation_results(self) -> None:
+        """Prints validation results to the console."""
+        if not self.validation_errors and not self.warnings:
+            print("\033[92m✓ All environment variables are valid\033[0m")
+            return
+
+        if self.warnings:
+            print("\033[93m! Warnings:\033[0m")
+            for warning in self.warnings:
+                print(f"\033[93m  - {warning}\033[0m")
+
+        if self.validation_errors:
+            print("\033[91m✗ Validation errors:\033[0m")
+            for error in self.validation_errors:
+                print(f"\033[91m  - {error}\033[0m")
+
+            print("\n\033[93mPlease check your .env file and set all required variables.\033[0m")
+            print("\033[93mRun 'python create_env_template.py' to generate a template.\033[0m")
+
+    def validate_or_exit(self) -> None:
+        """Validates all environment variables and exits if validation fails."""
+        if not self.validate_all():
+            self.print_validation_results()
+            sys.exit(1)
+        else:
+            # Just print warnings if any
+            if self.warnings:
+                self.print_validation_results()
+
+    def add_variable(self, name: str, config: dict, category: Optional[str] = None) -> None:
+        """
+        Add a new environment variable to the validator.
+
+        Args:
+            name: The environment variable name
+            config: Dictionary with validation configuration
+            category: Optional category name for template organization
+        """
+        # Add to required_vars dictionary
+        self.required_vars[name] = config
+
+        # Add to appropriate category if specified
+        if category and category in self.CATEGORIES and name not in self.CATEGORIES[category]:
+            self.CATEGORIES[category].append(name)
+
+
+def generate_env_template() -> None:
+    """Generates a .env.template file with all required variables."""
+    validator = EnvValidator()
+
+    lines = ["# Environment Variables Template", "# ============================", ""]
+
+    for category, var_names in validator.CATEGORIES.items():
+        lines.append(f"# {category}")
+        for var_name in var_names:
+            var_config = validator.required_vars.get(var_name, {})
+            comment = f"# {var_config.get('description', '')}"
+
+            if var_config.get("required", False):
+                comment += " (Required)"
+
+            if "default" in var_config:
+                value = var_config["default"]
+                lines.append(f"{comment}")
+                lines.append(f"{var_name}={value}")
+            else:
+                value = ""
+                lines.append(f"{comment}")
+                lines.append(f"{var_name}={value}")
+
+            lines.append("")
+
+    # Write to file
+    env_template_path = ".env.template"
+    with open(env_template_path, "w") as f:
+        f.write("\n".join(lines))
+
+    print(f".env.template created at {os.path.abspath(env_template_path)}")
+    print("Copy this file to .env and fill in the required values.")
+
+
+def generate_clean_env_file() -> None:
+    """
+    Generates a clean .env file from the template that's compatible
+    with python-dotenv parser.
+    """
+    validator = EnvValidator()
+
+    lines = []
+
+    for category, var_names in validator.CATEGORIES.items():
+        lines.append(f"# {category}")
+        for var_name in var_names:
+            var_config = validator.required_vars.get(var_name, {})
+
+            # Add the variable name with its default value if available
+            if "default" in var_config:
+                value = var_config["default"]
+                lines.append(f"{var_name}={value}")
+            else:
+                lines.append(f"{var_name}=")
+
+        # Add a blank line between categories
+        lines.append("")
+
+    # Write to file
+    env_path = ".env"
+    with open(env_path, "w") as f:
+        f.write("\n".join(lines))
+
+    print(f"Clean .env file created at {os.path.abspath(env_path)}")
+    print("Please fill in the required values.")
+
+
+# Function to call at application startup
+def validate_environment() -> None:
+    """Validates environment variables at application startup."""
+    validator = EnvValidator()
+    validator.validate_or_exit()
+
+
+if __name__ == "__main__":
+    # If the script is run directly, generate both files
+    generate_env_template()
+    generate_clean_env_file()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+import plugin
 import uvicorn
 from fastapi.staticfiles import StaticFiles
 import uvicorn, os

--- a/plugin.py
+++ b/plugin.py
@@ -1,0 +1,32 @@
+"""
+Environment Variable Validation Plugin
+"""
+import os
+import sys
+from pathlib import Path
+
+# Find the root directory
+current_dir = Path(__file__).resolve().parent
+root_dir = current_dir
+# Add any logic here to find your project root if needed
+
+# Add the root directory to the Python path
+sys.path.insert(0, str(root_dir))
+
+# Import the validator
+try:
+    from env_validator import validate_environment
+
+    # Run validation
+    validate_environment()
+except ImportError:
+    print("\033[93mWarning: Environment validator not found.\033[0m")
+    print("\033[93mMake sure env_validator.py is in your project root.\033[0m")
+    # Don't exit, allow the application to continue
+except Exception as e:
+    print(f"\033[91mError validating environment variables: {str(e)}\033[0m")
+    if os.environ.get("PYTHON_ENV") != "prod":
+        print("\033[93mContinuing despite validation errors (non-production environment).\033[0m")
+    else:
+        print("\033[91mExiting due to validation errors in production environment.\033[0m")
+        sys.exit(1)

--- a/tests/test_env_validator.py
+++ b/tests/test_env_validator.py
@@ -1,0 +1,273 @@
+import os
+import pytest
+import sys
+from unittest.mock import patch, MagicMock
+
+# Import the module to test
+from env_validator import EnvValidator, validate_environment
+
+
+class TestEnvValidator:
+    def setup_method(self):
+        """Setup method for tests."""
+        # Create a fresh validator for each test
+        self.validator = EnvValidator()
+
+        # Backup existing environment variables and clear for test
+        self.env_backup = os.environ.copy()
+        os.environ.clear()
+
+    def teardown_method(self):
+        """Teardown method for tests."""
+        # Restore environment variables
+        os.environ.clear()
+        os.environ.update(self.env_backup)
+
+    def test_init(self):
+        """Test the initialization of EnvValidator."""
+        assert isinstance(self.validator.required_vars, dict)
+        assert len(self.validator.required_vars) > 0
+        assert len(self.validator.validation_errors) == 0
+        assert len(self.validator.warnings) == 0
+
+    def test_validate_all_success(self):
+        """Test validation with all required variables set."""
+        # Set all required variables in the environment
+        for var_name, req in self.validator.required_vars.items():
+            if req.get("required", False):
+                if "default" in req:
+                    os.environ[var_name] = req["default"]
+                elif "min_length" in req:
+                    os.environ[var_name] = "x" * req["min_length"]
+                elif "allowed_values" in req and req["allowed_values"]:
+                    os.environ[var_name] = req["allowed_values"][0]
+                elif req.get("type") == "int":
+                    os.environ[var_name] = "123"
+                else:
+                    os.environ[var_name] = "test_value"
+
+        # Run validation
+        result = self.validator.validate_all()
+
+        # Check results
+        assert result is True
+        assert len(self.validator.validation_errors) == 0
+
+    def test_validate_all_missing_required(self):
+        """Test validation with missing required variables."""
+        # Leave environment empty to ensure required variables are missing
+
+        # Run validation
+        result = self.validator.validate_all()
+
+        # Check results
+        assert result is False
+        assert len(self.validator.validation_errors) > 0
+
+        # Check for expected error messages
+        for var_name, req in self.validator.required_vars.items():
+            if req.get("required", False) and "default" not in req:
+                expected_error = f"{var_name} is required but not set"
+                assert any(expected_error in error for error in self.validator.validation_errors)
+
+    def test_validate_default_values(self):
+        """Test validation with default values."""
+        # Run validation with empty environment
+        self.validator.validate_all()
+
+        # Check if warnings for defaults are generated
+        for var_name, req in self.validator.required_vars.items():
+            if req.get("required", False) and "default" in req:
+                expected_warning = f"{var_name} is using default value: {req['default']}"
+                assert any(expected_warning in warning for warning in self.validator.warnings)
+
+    def test_validate_type_int(self):
+        """Test validation of integer type variables."""
+        # Find an integer variable
+        int_vars = [var_name for var_name, req in self.validator.required_vars.items()
+                    if req.get("type") == "int" and req.get("required", False)]
+
+        if not int_vars:
+            pytest.skip("No integer type variables to test")
+
+        var_name = int_vars[0]
+
+        # Test with valid integer
+        os.environ[var_name] = "123"
+        self.validator.validate_all()
+        error_message = f"{var_name} must be an integer"
+        assert not any(error_message in error for error in self.validator.validation_errors)
+
+        # Test with invalid integer
+        os.environ[var_name] = "not_an_integer"
+        self.validator.validate_all()
+        assert any(error_message in error for error in self.validator.validation_errors)
+
+    def test_validate_min_length(self):
+        """Test validation of minimum length requirement."""
+        # Find a variable with min_length
+        min_length_vars = [var_name for var_name, req in self.validator.required_vars.items()
+                           if "min_length" in req and req.get("required", False)]
+
+        if not min_length_vars:
+            pytest.skip("No min_length variables to test")
+
+        var_name = min_length_vars[0]
+        min_length = self.validator.required_vars[var_name]["min_length"]
+
+        # Test with valid length
+        os.environ[var_name] = "x" * min_length
+        self.validator.validate_all()
+        error_message = f"{var_name} must be at least {min_length} characters long"
+        assert not any(error_message in error for error in self.validator.validation_errors)
+
+        # Test with invalid length
+        os.environ[var_name] = "x" * (min_length - 1)
+        self.validator.validate_all()
+        assert any(error_message in error for error in self.validator.validation_errors)
+
+    def test_validate_allowed_values(self):
+        """Test validation of allowed values."""
+        # Find a variable with allowed_values
+        allowed_values_vars = [var_name for var_name, req in self.validator.required_vars.items()
+                               if "allowed_values" in req and req.get("required", False)]
+
+        if not allowed_values_vars:
+            pytest.skip("No allowed_values variables to test")
+
+        var_name = allowed_values_vars[0]
+        allowed_values = self.validator.required_vars[var_name]["allowed_values"]
+
+        # Test with valid value
+        os.environ[var_name] = allowed_values[0]
+        self.validator.validate_all()
+        error_message = f"{var_name} must be one of: {', '.join(allowed_values)}"
+        assert not any(error_message in error for error in self.validator.validation_errors)
+
+        # Test with invalid value
+        os.environ[var_name] = "invalid_value"
+        self.validator.validate_all()
+        assert any(error_message in error for error in self.validator.validation_errors)
+
+    def test_print_validation_results_success(self):
+        """Test printing validation results with success."""
+        # Mock print function
+        with patch('builtins.print') as mock_print:
+            # Simulate successful validation
+            self.validator.validation_errors = []
+            self.validator.warnings = []
+
+            # Call the method
+            self.validator.print_validation_results()
+
+            # Verify output
+            mock_print.assert_called_once_with("\033[92m✓ All environment variables are valid\033[0m")
+
+    def test_print_validation_results_warnings(self):
+        """Test printing validation results with warnings."""
+        # Mock print function
+        with patch('builtins.print') as mock_print:
+            # Simulate warnings
+            self.validator.validation_errors = []
+            self.validator.warnings = ["Warning 1", "Warning 2"]
+
+            # Call the method
+            self.validator.print_validation_results()
+
+            # Verify output
+            assert mock_print.call_count >= 3
+            mock_print.assert_any_call("\033[93m! Warnings:\033[0m")
+
+    def test_print_validation_results_errors(self):
+        """Test printing validation results with errors."""
+        # Mock print function
+        with patch('builtins.print') as mock_print:
+            # Simulate errors
+            self.validator.validation_errors = ["Error 1", "Error 2"]
+            self.validator.warnings = []
+
+            # Call the method
+            self.validator.print_validation_results()
+
+            # Verify output
+            assert mock_print.call_count >= 3
+            mock_print.assert_any_call("\033[91m✗ Validation errors:\033[0m")
+
+    def test_validate_or_exit_success(self):
+        """Test validate_or_exit with successful validation."""
+        # Mock validate_all to return True
+        with patch.object(self.validator, 'validate_all', return_value=True), \
+                patch.object(self.validator, 'print_validation_results') as mock_print:
+            # Call the method
+            self.validator.validate_or_exit()
+
+            # Verify behavior
+            mock_print.assert_not_called()
+
+    def test_validate_or_exit_with_warnings(self):
+        """Test validate_or_exit with warnings."""
+        # Mock validate_all to return True but with warnings
+        with patch.object(self.validator, 'validate_all', return_value=True), \
+                patch.object(self.validator, 'print_validation_results') as mock_print:
+            # Set warnings
+            self.validator.warnings = ["Warning"]
+
+            # Call the method
+            self.validator.validate_or_exit()
+
+            # Verify behavior
+            mock_print.assert_called_once()
+
+    @patch('sys.exit')
+    def test_validate_or_exit_failure(self, mock_exit):
+        """Test validate_or_exit with validation failure."""
+        # Mock validate_all to return False
+        with patch.object(self.validator, 'validate_all', return_value=False), \
+                patch.object(self.validator, 'print_validation_results') as mock_print:
+            # Call the method
+            self.validator.validate_or_exit()
+
+            # Verify behavior
+            mock_print.assert_called_once()
+            mock_exit.assert_called_once_with(1)
+
+    @patch('sys.exit')
+    def test_validate_environment(self, mock_exit):
+        """Test the validate_environment function."""
+        # Mock EnvValidator
+        with patch('env_validator.EnvValidator') as MockValidator:
+            # Setup mock validator
+            mock_validator = MagicMock()
+            MockValidator.return_value = mock_validator
+
+            # Call function
+            validate_environment()
+
+            # Verify behavior
+            MockValidator.assert_called_once()
+            mock_validator.validate_or_exit.assert_called_once()
+
+
+# Additional test for template generation
+class TestEnvTemplateGeneration:
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('os.path.abspath', return_value='/path/to/.env.template')
+    @patch('builtins.print')
+    def test_generate_env_template(self, mock_print, mock_abspath, mock_open):
+        """Test generating the environment template."""
+        from env_validator import generate_env_template
+
+        # Setup mock for file write
+        mock_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        # Call function
+        generate_env_template()
+
+        # Verify file was written to
+        mock_open.assert_called_once_with(".env.template", "w")
+        assert mock_file.write.call_count == 1
+
+        # Verify output messages
+        mock_print.assert_any_call(".env.template created at /path/to/.env.template")
+        mock_print.assert_any_call("Copy this file to .env and fill in the required values.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description


This pull request introduces an environment variable validator to ensure all required environment variables are properly set at application startup. The validator checks for the presence and proper formatting of critical environment variables, preventing the application from starting with a misconfigured environment which could lead to runtime errors.

​

## Related Issue: #996  ([Link to issue ticket](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/996))

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Our application currently relies on several environment variables, but lacks validation to ensure they are properly configured. This may lead to:

- Silent failures when variables are missing
- Runtime errors that are difficult to debug
- Inconsistent behavior across different environments
- Confusion during onboarding for new team members

This change implements a robust validator that runs during application initialization to ensure proper configuration before the application starts.
​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests were written to verify validation of all required variables
- Tests include positive cases (all variables correctly set) and negative cases (missing or malformed variables)
- Manually tested across development, staging, and production-like environments
- Verified error messages are clear and actionable.
​

## Screenshots (if appropriate - Postman, etc):
![Screenshot from 2025-02-27 21-53-59](https://github.com/user-attachments/assets/6a29a105-e735-4561-adc3-51d8b835d28d)
![Screenshot from 2025-02-27 22-12-07](https://github.com/user-attachments/assets/7d4ca8d3-1ce2-466f-9a81-260aba5345fa)
![Screenshot from 2025-02-27 22-48-29](https://github.com/user-attachments/assets/d50a4e65-cd7f-4036-9a6f-e00e09bd5e3e)
![Screenshot from 2025-02-27 23-41-01](https://github.com/user-attachments/assets/a83c1d5f-ce9d-460a-b2b5-44c2cedad115)
![Screenshot from 2025-02-27 23-42-30](https://github.com/user-attachments/assets/b185eb36-54ed-442e-9202-43736e81a820)
![Screenshot from 2025-02-27 23-49-52](https://github.com/user-attachments/assets/03173ae9-5a6a-46f1-bc8b-5f7ff3164dbd)
![Screenshot from 2025-02-27 22-19-44](https://github.com/user-attachments/assets/495b24ea-eeae-45dc-adb7-a6663633bd8e)
![Screenshot from 2025-02-27 22-29-42](https://github.com/user-attachments/assets/18530142-6932-44f2-8080-c1fdaa8fda62)




​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
