### PR TITLE
fix: rename duplicate exception handlers for clarity 

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ async def validation_exception(request: Request, exc: RequestValidationError):
 
 
 @app.exception_handler(IntegrityError)
-async def exception(request: Request, exc: IntegrityError):
+async def integrity_exception(request: Request, exc: IntegrityError):
     """Integrity error exception handlers"""
 
     logger.exception(f"Exception occured; {exc}")
@@ -134,7 +134,7 @@ async def exception(request: Request, exc: IntegrityError):
 
 
 @app.exception_handler(Exception)
-async def exception(request: Request, exc: Exception):
+async def global_exception(request: Request, exc: Exception):
     """Other exception handlers"""
 
     logger.exception(f"Exception occured; {exc}")


### PR DESCRIPTION
---
## **Description**  
This PR renames the existing `IntegrityError` and `Exception` handlers to have more descriptive names. The changes improve readability and maintainability, making it easier to identify specific exception handlers in the codebase.  

### **Changes Implemented:**  
- Renamed `exception` handler for `IntegrityError` to `integrity_exception`.  
- Renamed `exception` handler for `Exception` to `global_exception`.  
- Updated all references to these handlers in the hng_boilerplate_python_fastapi_web app.  

---

## **Related Issue (Link to issue ticket)**  
Closes #[1042](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1042) – Rename Exception Handlers for Clarity  

---

## **Motivation and Context**  
Renaming these handlers helps in distinguishing between different types of exceptions. This is important for debugging and logging, ensuring that each exception is explicitly named according to its function.  

---

## **How Has This Been Tested?**  
- Tested using **Postman** to trigger both IntegrityError and general exceptions.  
- Verified logs in **error.log**.  
- Ran unit tests to confirm correct behavior of exception handling.  

---
 

**Before Change:**  
![before_refactoring_exception_name](https://github.com/user-attachments/assets/ba6834d7-557c-41b6-8601-7f81bc9ba02d)

**After Change:** 
![exception_handler](https://github.com/user-attachments/assets/864a8a26-1185-40b2-9cb9-1d96d720daff)

![screen](https://github.com/user-attachments/assets/9e02dca2-a9b4-4d5f-b023-a7d4458554fa)

---

## **Types of Changes**  

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  

---

## **Checklist:**  

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---