### PR TITLE
feat(notification): implement mark notifications as read

### DIFF
--- a/api/v1/routes/notification.py
+++ b/api/v1/routes/notification.py
@@ -95,6 +95,20 @@ def get_all_notifications(
     )
 
 
+@notification.delete("/clear", 
+    summary="Mark current user notifications as read",
+    status_code=status.HTTP_200_OK
+)
+async def mark_notifications_as_read(
+    current_user=Depends(user_service.get_current_user),
+    db: Session = Depends(get_db),
+):
+    notification_service.mark_notifications_as_read(current_user, db)
+    return success_response(
+        status_code=200, message="All notifications marked as read successfully.", data={}
+    )
+
+
 @notification.delete("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_notification(
     notification_id: str,

--- a/api/v1/services/notification.py
+++ b/api/v1/services/notification.py
@@ -19,6 +19,24 @@ class NotificationService(Service):
         db.refresh(new_notification)
         return new_notification
 
+
+    def mark_notifications_as_read(
+        self,
+        user: User,
+        db: Session = Depends(get_db),
+    ):
+        unread_notifications = (
+            db.query(Notification).filter(Notification.status == "unread").all()
+        )
+
+        if not unread_notifications:
+            raise HTTPException(status_code=404, detail="No unread notifications found.")
+
+        for unread_notification in unread_notifications:
+            unread_notification.status = "read"
+
+        db.commit()
+
     def mark_notification_as_read(
         self,
         notification_id: str,

--- a/tests/v1/notification/test_notification.py
+++ b/tests/v1/notification/test_notification.py
@@ -63,6 +63,22 @@ notification = Notification(
     updated_at=updated_at,
 )
 
+def test_mark_notifications_as_read(client, db_session_mock):
+    db_session_mock.query().filter(Notification.status == "unread").all.return_value = [user, notification]
+    headers = {"authorization": f"Bearer {access_token}"}
+    response = client.delete("/api/v1/notifications/clear", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["success"] == True
+    assert response.json()["status_code"] == 200
+    assert response.json()["message"] == "All notifications marked as read successfully."
+
+
+def test_mark_notifications_as_read_unauthenticated_user(client, db_session_mock):
+    db_session_mock.query().filter(Notification.status == "unread").all.return_value = [notification]
+    response = client.delete("/api/v1/notifications/clear")
+    assert response.status_code == 401
+
 
 def test_mark_notification_as_read(client, db_session_mock):
 


### PR DESCRIPTION
## Description

Implement an endpoint to mark all notifications as read for the authenticated user.

## Related Issue (Link to issue ticket)

[Closes Issue 1053](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1053)

## Motivation and Context

To allow users to clear all their unread notifications at once, improving user experience by keeping their notification list organized.

## How Has This Been Tested?

The changes have been tested using unit tests and Postman

## Screenshots (if appropriate - Postman, etc):

![successfully update unread notifications](https://github.com/user-attachments/assets/1549d0af-e972-4a4f-af3c-a9fb124d270b)
![when there is no unread message](https://github.com/user-attachments/assets/53cfd1a4-dca7-418b-8a41-31dbc1b30a01)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​
## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
