### PR TITLE
Fix: functionality issue with dislike create method and update related tests

### DIFF
--- a/api/v1/routes/comment.py
+++ b/api/v1/routes/comment.py
@@ -86,7 +86,7 @@ async def dislike_comment(
 
     return success_response(
         message=dislike.get("message"),
-        status_code=dislike.get("status_code"),
+        status_code=status.HTTP_201_CREATED,
         data=jsonable_encoder(dislike),
     )
 

--- a/api/v1/routes/comment.py
+++ b/api/v1/routes/comment.py
@@ -85,8 +85,8 @@ async def dislike_comment(
     )
 
     return success_response(
-        message="Comment disliked successfully!",
-        status_code=201,
+        message=dislike.get("message"),
+        status_code=dislike.get("status_code"),
         data=jsonable_encoder(dislike),
     )
 

--- a/tests/v1/comment/test_dislike_comment.py
+++ b/tests/v1/comment/test_dislike_comment.py
@@ -115,5 +115,5 @@ def test_dislike_comment_twice(
     if response.status_code != 201:
         print(response.json())  # Print error message for more details
 
-    assert response.status_code == 400, f"Expected status code 200, got {response.status_code}"
-    assert response.json()['message'] == "You can only dislike once"
+    assert response.status_code == 201, f"Expected status code 201, got {response.status_code}"
+    assert response.json()['message'] == "Dislike removed successfully"

--- a/tests/v1/comment/test_dislike_comment.py
+++ b/tests/v1/comment/test_dislike_comment.py
@@ -84,7 +84,7 @@ def test_dislike_comment(
         print(response.json())  # Print error message for more details
 
     assert response.status_code == 201, f"Expected status code 200, got {response.status_code}"
-    assert response.json()['message'] == "Comment disliked successfully!"
+    assert response.json()['message'] == "Dislike added successfully"
 
 def test_dislike_comment_twice(
     mock_db_session, 


### PR DESCRIPTION
## Description
This pull request implements the toggle functionality for the comment dislike feature, allowing users to both add and remove dislikes on comments. It includes a check to ensure that the comment exists before processing the dislike action. Additionally, error handling has been improved to provide clearer feedback for missing comments and potential database issues.

## Related Issue (Link to issue ticket)
- [#1101](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1101) 

## Motivation and Context
This change is essential as it enhances the user experience by allowing users to toggle their dislike status on comments. Previously, users could only dislike a comment once. The updates to the error handling ensure that users receive informative messages regarding the status of their actions, contributing to a more robust application.

## How Has This Been Tested?
I have updated the testing suite to cover the new toggle functionality and to validate that the error handling works as intended. Tests were run in a local development environment, and all new and existing tests passed successfully. The test cases include scenarios for adding, removing, and attempting to dislike non-existent comments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
