### PR TITLE
fix: fix rate limiting on all auth routes

### DIFF
--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -17,8 +17,7 @@ from api.v1.schemas.user import Token
 from api.v1.schemas.user import (LoginRequest, UserCreate, EmailRequest,
                                  ProfileData, UserData2)
 from api.v1.schemas.token import TokenRequest
-from api.v1.schemas.user import (UserCreate,
-                                 MagicLinkRequest,
+from api.v1.schemas.user import (MagicLinkRequest,
                                  ChangePasswordSchema,
                                  AuthMeResponse)
 from api.v1.services.organisation import organisation_service
@@ -34,7 +33,7 @@ auth = APIRouter(prefix="/auth", tags=["Authentication"])
 limiter = Limiter(key_func=get_remote_address)
   
 @auth.post("/register", status_code=status.HTTP_201_CREATED, response_model=auth_response)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def register(request: Request, background_tasks: BackgroundTasks, response: Response, user_schema: UserCreate, db: Session = Depends(get_db)):
     '''Endpoint for a user to register their account'''
 
@@ -94,7 +93,7 @@ def register(request: Request, background_tasks: BackgroundTasks, response: Resp
 
 
 @auth.post(path="/register-super-admin", status_code=status.HTTP_201_CREATED, response_model=auth_response)
-@limiter.limit("1000/minute")  # Limit to 5 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def register_as_super_admin(request: Request, user: UserCreate, db: Session = Depends(get_db)):
     """Endpoint for super admin creation"""
 
@@ -138,7 +137,7 @@ def register_as_super_admin(request: Request, user: UserCreate, db: Session = De
 
 
 @auth.post("/login", status_code=status.HTTP_200_OK, response_model=auth_response)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def login(request: Request, login_request: LoginRequest, db: Session = Depends(get_db)):
     """Endpoint to log in a user"""
 
@@ -179,7 +178,7 @@ def login(request: Request, login_request: LoginRequest, db: Session = Depends(g
 
 
 @auth.post("/logout", status_code=status.HTTP_200_OK)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def logout(
     request: Request, 
     response: Response,
@@ -197,7 +196,7 @@ def logout(
 
 
 @auth.post("/refresh-access-token", status_code=status.HTTP_200_OK)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def refresh_access_token(
     request: Request, response: Response, db: Session = Depends(get_db)
 ):
@@ -231,7 +230,7 @@ def refresh_access_token(
 
 
 @auth.post("/request-token", status_code=status.HTTP_200_OK)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 async def request_signin_token(request: Request, background_tasks: BackgroundTasks,
     email_schema: EmailRequest, db: Session = Depends(get_db)
 ):
@@ -265,7 +264,7 @@ async def request_signin_token(request: Request, background_tasks: BackgroundTas
 
 
 @auth.post("/verify-token", status_code=status.HTTP_200_OK, response_model=auth_response)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 async def verify_signin_token(
     request: Request, 
     token_schema: TokenRequest, db: Session = Depends(get_db)
@@ -308,7 +307,7 @@ async def verify_signin_token(
 
 # TODO: Fix magic link authentication
 @auth.post("/magic-link", status_code=status.HTTP_200_OK)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def request_magic_link(
     request: Request, 
     requests: MagicLinkRequest, background_tasks: BackgroundTasks,
@@ -335,7 +334,7 @@ def request_magic_link(
 
 
 @auth.post("/magic-link/verify")
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 async def verify_magic_link(request: Request, token_schema: Token, db: Session = Depends(get_db)):
     user, access_token = AuthService.verify_magic_token(token_schema.token, db)
     user_organizations = organisation_service.retrieve_user_organizations(user, db)
@@ -369,7 +368,7 @@ async def verify_magic_link(request: Request, token_schema: Token, db: Session =
 
 
 @auth.put("/password", status_code=200)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 async def change_password(
     request: Request, 
     schema: ChangePasswordSchema,
@@ -388,7 +387,7 @@ async def change_password(
 @auth.get("/@me",
           status_code=status.HTTP_200_OK,
           response_model=AuthMeResponse)
-@limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
+@limiter.limit("5/minute")  # Limit to 5 requests per minute per IP
 def get_current_user_details(
     request: Request, 
     db: Annotated[Session, Depends(get_db)],

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 from fastapi.templating import Jinja2Templates
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -93,6 +94,18 @@ async def http_exception(request: Request, exc: HTTPException):
             "status": False,
             "status_code": exc.status_code,
             "message": exc.detail,
+        },
+    )
+    
+@app.exception_handler(RateLimitExceeded)
+async def custom_rate_limit_handler(request: Request, exc: RateLimitExceeded):
+    """Rate limit exceeded exception handler"""
+    return JSONResponse(
+        status_code=429,
+        content={
+            "status": False,
+            "status_code": exc.status_code,
+            "message": "Too many requests. Please try again in 60 seconds.",
         },
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,23 @@
+import itertools
 import sys, os
 import warnings
 from unittest.mock import patch
 import pytest
 
- 
+
+
+# Global IP generator (supports 16 million+ unique IPs)
+IP_GENERATOR = itertools.cycle(
+    (f"127.{i//65536}.{(i//256)%256}.{i%256}" for i in itertools.count())
+)
+
+@pytest.fixture(autouse=True)
+def auto_mock_client_ip():
+    """Automatically mock client IP for all tests"""
+    with patch("fastapi.Request.client") as mock_client:
+        mock_client.host = next(IP_GENERATOR)
+        yield
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -13,5 +27,4 @@ def mock_send_email():
     with patch("api.core.dependencies.email_sender.send_email") as mock_email_sending:
         with patch("fastapi.BackgroundTasks.add_task") as add_task_mock:
             add_task_mock.side_effect = lambda func, *args, **kwargs: func(*args, **kwargs)
-            
             yield mock_email_sending

--- a/tests/v1/auth/test_rate_limiting.py
+++ b/tests/v1/auth/test_rate_limiting.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.db.database import get_db
+from main import app
+
+client = TestClient(app)
+
+# Mock the database dependency
+@pytest.fixture
+def db_session_mock():
+    """Mock the database dependency"""
+    db_session = MagicMock()
+    yield db_session
+
+# Override the dependency with the mock
+@pytest.fixture(autouse=True)
+def override_get_db(db_session_mock):
+    """Override the get_db dependency with the mock"""
+    def get_db_override():
+        yield db_session_mock
+
+    app.dependency_overrides[get_db] = get_db_override
+    yield
+
+    app.dependency_overrides = {}
+
+def test_rate_limiting(db_session_mock, mock_send_email, mocker):
+    """Test registration endpoint rate limiting with IP mocking"""
+    # Mock database operations
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+    db_session_mock.add.return_value = None
+    db_session_mock.commit.return_value = None
+
+    # Mock IP address for all requests
+    mock_client = mocker.patch("fastapi.Request.client")
+    mock_client.host = "192.168.123.132"
+   
+    unique_email = f"rate.limit.{uuid.uuid4()}@gmail.com"
+
+    user_template = {
+        "password": "strin8Hsg263@",
+        "first_name": "string",
+        "last_name": "string",
+        "email": unique_email
+    }
+
+    # First 5 requests from same IP
+    for _ in range(5):
+        mock_client = mocker.patch("fastapi.Request.client")
+        mock_client.host = "192.168.123.132"
+        response = client.post("/api/v1/auth/register", json=user_template)
+        assert response.status_code == 201
+
+    # Sixth request from same IP should be blocked
+    response = client.post("/api/v1/auth/register", json=user_template)
+    assert response.status_code == 429
+    assert "Too many requests" in response.json()["message"]

--- a/tests/v1/auth/test_signup.py
+++ b/tests/v1/auth/test_signup.py
@@ -65,26 +65,3 @@ def test_user_fields(db_session_mock, mock_send_email):
     assert response.json()['data']["user"]['first_name'] == "sunday"
     assert response.json()['data']["user"]['last_name'] == "mba"
     # mock_send_email.assert_called_once()
-    
-def test_rate_limiting(db_session_mock):
-    db_session_mock.query(User).filter().first.return_value = None
-    db_session_mock.add.return_value = None
-    db_session_mock.commit.return_value = None
-    
-    unique_email = f"rate.limit.{uuid.uuid4()}@gmail.com"
-    user = {
-        "password": "ValidP@ssw0rd!",
-        "first_name": "Rate",
-        "last_name": "Limit",
-        "email": unique_email
-    }
-
-
-    response = client.post("/api/v1/auth/register", json=user)
-    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.json()}"
-    
-    time.sleep(5)  # Adjust this delay to see if it prevents rate limiting
-
-    for _ in range(5):
-        response = client.post("/api/v1/auth/register", json=user)
-        assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.json()}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

​

## Description
This update implements enhanced rate-limiting protections across sensitive authentication endpoints to mitigate brute-force attacks and API abuse. Rate limits have been configured for critical security routes including `api/v1/auth/login`, `api/v1/auth/register`, and` api/v1/auth/password-reset`, along with all other authentication-related API paths. A default threshold of 5 requests per minute per IP address has been enforced for these protected endpoints, providing consistent throttling against excessive requests while maintaining accessibility for legitimate users.

## Related Issue (Link to issue ticket)
#1011 

## How Has This Been Tested?
yes


​

## Screenshots (if appropriate - Postman, etc):
![Screenshot from 2025-02-28 15-00-22](https://github.com/user-attachments/assets/9d29d791-359e-45a1-86dc-9441cb948717)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
