### PR TITLE
Feat/product categories delete

### DIFF
--- a/api/v1/routes/product.py
+++ b/api/v1/routes/product.py
@@ -117,6 +117,24 @@ def update_product_category(
     )
 
 
+@non_organisation_product.delete(
+    "/categories/{category}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_product_category(
+    category: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user),
+):
+    """
+    Endpoint to delete a product category using its unique name.
+    """
+    ProductCategoryService.delete(db, category)
+    return success_response(
+        status_code=status.HTTP_204_NO_CONTENT,
+        message="Category deleted successfully",
+    )
+
+
 @non_organisation_product.get(
     "/categories", response_model=success_response, status_code=200
 )

--- a/api/v1/routes/product.py
+++ b/api/v1/routes/product.py
@@ -4,15 +4,19 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import Annotated
 from typing import List, Optional
-
 from api.utils.pagination import paginated_response
 from api.utils.success_response import success_response
 from api.db.database import get_db
-from api.v1.models.product import Product, ProductFilterStatusEnum, ProductStatusEnum
+from api.v1.models.product import (
+    Product,
+    ProductFilterStatusEnum,
+    ProductStatusEnum,
+)
 from api.v1.services.product import product_service, ProductCategoryService
 from api.v1.schemas.product import (
     ProductCategoryCreate,
     ProductCategoryData,
+    ProductCategoryUpdate,
     ProductCreate,
     ProductList,
     ProductUpdate,
@@ -30,13 +34,19 @@ from api.v1.models import User
 non_organisation_product = APIRouter(prefix="/products", tags=["Products"])
 
 
-@non_organisation_product.get("", response_model=success_response, status_code=200)
+@non_organisation_product.get(
+    "", response_model=success_response, status_code=200
+)
 async def get_all_products(
-    current_user: Annotated[User, Depends(user_service.get_current_super_admin)],
-    limit: Annotated[int, Query(
-        ge=1, description="Number of products per page")] = 10,
-    skip: Annotated[int, Query(
-        ge=1, description="Page number (starts from 1)")] = 0,
+    current_user: Annotated[
+        User, Depends(user_service.get_current_super_admin)
+    ],
+    limit: Annotated[
+        int, Query(ge=1, description="Number of products per page")
+    ] = 10,
+    skip: Annotated[
+        int, Query(ge=1, description="Page number (starts from 1)")
+    ] = 0,
     db: Session = Depends(get_db),
 ):
     """Endpoint to get all products. Only accessible to superadmin"""
@@ -45,7 +55,9 @@ async def get_all_products(
 
 
 # categories
-@non_organisation_product.post("/categories", status_code=status.HTTP_201_CREATED)
+@non_organisation_product.post(
+    "/categories", status_code=status.HTTP_201_CREATED
+)
 def create_product_category(
     category_schema: ProductCategoryCreate,
     current_user: User = Depends(user_service.get_current_user),
@@ -65,12 +77,43 @@ def create_product_category(
     """
 
     new_category = ProductCategoryService.create(
-        db, category_schema, current_user)
+        db, category_schema, current_user
+    )
 
     return success_response(
         status_code=status.HTTP_201_CREATED,
         message="Category successfully created",
         data=jsonable_encoder(new_category),
+    )
+
+
+@non_organisation_product.patch(
+    "/categories/{category}", status_code=status.HTTP_200_OK
+)
+def update_product_category(
+    category: str,
+    category_schema: ProductCategoryUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_user),
+):
+    """Endpoint to update a product category using its unique name.
+
+    Args:
+        category_name (str): The unique name of the product category to update.
+        category_schema (ProductCategoryUpdate): The update schema containing fields to update.
+        current_user (User): The currently authenticated user.
+        db (Session): The database session.
+
+    Returns:
+        A success response with the updated product category.
+    """
+    updated_category = ProductCategoryService.update(
+        db, category, category_schema
+    )
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Category updated successfully",
+        data=jsonable_encoder(updated_category),
     )
 
 
@@ -102,7 +145,8 @@ def retrieve_categories(
 
 
 product = APIRouter(
-    prefix="/organisations/{org_id}/products", tags=["Products"])
+    prefix="/organisations/{org_id}/products", tags=["Products"]
+)
 
 
 # create
@@ -253,10 +297,12 @@ def delete_product(
 def get_organisation_products(
     org_id: str,
     current_user: Annotated[User, Depends(user_service.get_current_user)],
-    limit: Annotated[int, Query(
-        ge=1, description="Number of products per page")] = 10,
-    page: Annotated[int, Query(
-        ge=1, description="Page number (starts from 1)")] = 1,
+    limit: Annotated[
+        int, Query(ge=1, description="Number of products per page")
+    ] = 10,
+    page: Annotated[
+        int, Query(ge=1, description="Page number (starts from 1)")
+    ] = 1,
     db: Session = Depends(get_db),
 ):
     """
@@ -329,11 +375,14 @@ async def get_products_by_filter_status(
             db=db, org_id=org_id, filter_status=filter_status
         )
         return SuccessResponse(
-            message="Products retrieved successfully", status_code=200, data=products
+            message="Products retrieved successfully",
+            status_code=200,
+            data=products,
         )
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail="Failed to retrieve products")
+            status_code=500, detail="Failed to retrieve products"
+        )
 
 
 @product.get(
@@ -350,30 +399,41 @@ async def get_products_by_status(
     """Endpoint to get products by status"""
     try:
         products = product_service.fetch_by_status(
-            db=db, org_id=org_id, status=status)
+            db=db, org_id=org_id, status=status
+        )
         return SuccessResponse(
-            message="Products retrieved successfully", status_code=200, data=products
+            message="Products retrieved successfully",
+            status_code=200,
+            data=products,
         )
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail="Failed to retrieve products")
+            status_code=500, detail="Failed to retrieve products"
+        )
 
 
-@product.get("/search", status_code=status.HTTP_200_OK, response_model=ProductList)
+@product.get(
+    "/search", status_code=status.HTTP_200_OK, response_model=ProductList
+)
 def search_products(
     org_id: str,
     name: Optional[str] = Query(None, description="Search by product name"),
     category: Optional[str] = Query(None, description="Filter by category"),
     min_price: Optional[float] = Query(
-        None, description="Filter by minimum price"),
+        None, description="Filter by minimum price"
+    ),
     max_price: Optional[float] = Query(
-        None, description="Filter by maximum price"),
-    limit: Annotated[int, Query(
-        ge=1, description="Number of products per page")] = 10,
-    page: Annotated[int, Query(
-        ge=1, description="Page number (starts from 1)")] = 1,
-    current_user: Annotated[User, Depends(
-        user_service.get_current_user)] = None,
+        None, description="Filter by maximum price"
+    ),
+    limit: Annotated[
+        int, Query(ge=1, description="Number of products per page")
+    ] = 10,
+    page: Annotated[
+        int, Query(ge=1, description="Page number (starts from 1)")
+    ] = 1,
+    current_user: Annotated[
+        User, Depends(user_service.get_current_user)
+    ] = None,
     db: Session = Depends(get_db),
 ):
     """

--- a/api/v1/schemas/product.py
+++ b/api/v1/schemas/product.py
@@ -1,4 +1,11 @@
-from pydantic import BaseModel, EmailStr, Field, PositiveFloat, ConfigDict, StringConstraints
+from pydantic import (
+    BaseModel,
+    EmailStr,
+    Field,
+    PositiveFloat,
+    ConfigDict,
+    StringConstraints,
+)
 from typing import List, Optional, Any, Dict, TypeVar, Generic, Annotated, List
 from datetime import datetime
 
@@ -160,22 +167,31 @@ class ProductCreate(BaseModel):
     quantity: int = 0
     image_url: str = "placeholder-image"
 
+
 class ProductCategoryRetrieve(BaseModel):
     name: str
     id: str
+
     class Config:
         from_attributes = True
 
+
 class ProductCategoryCreate(BaseModel):
     name: str
+
 
 class ProductCategoryData(BaseModel):
     name: str
 
 
-class ProductCommentCreate(BaseModel):
-    content: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+class ProductCategoryUpdate(BaseModel):
+    name: Optional[str] = None
 
+
+class ProductCommentCreate(BaseModel):
+    content: Annotated[
+        str, StringConstraints(strip_whitespace=True, min_length=1)
+    ]
 
 
 class ProductCommentsSchema(BaseModel):

--- a/api/v1/services/product.py
+++ b/api/v1/services/product.py
@@ -15,7 +15,11 @@ from api.v1.models.product import (
 )
 from api.v1.models.user import User
 from api.v1.models import Organisation
-from api.v1.schemas.product import ProductCategoryCreate, ProductCreate
+from api.v1.schemas.product import (
+    ProductCategoryCreate,
+    ProductCategoryUpdate,
+    ProductCreate,
+)
 from api.utils.db_validators import check_user_in_org
 from api.v1.schemas.product import ProductFilterResponse
 
@@ -39,7 +43,11 @@ class ProductService(Service):
     #     check_user_in_org(user=current_user, organisation=organisation)
 
     def create(
-        self, db: Session, schema: ProductCreate, org_id: str, current_user: User
+        self,
+        db: Session,
+        schema: ProductCreate,
+        org_id: str,
+        current_user: User,
     ):
         """Create a new product"""
 
@@ -54,7 +62,9 @@ class ProductService(Service):
         category_name = schema.category
         category = (
             db.query(ProductCategory)
-            .filter(func.lower(ProductCategory.name) == func.lower(category_name))
+            .filter(
+                func.lower(ProductCategory.name) == func.lower(category_name)
+            )
             .first()
         )
 
@@ -96,7 +106,12 @@ class ProductService(Service):
         return product
 
     def update(
-        self, db: Session, product_id: str, current_user: User, org_id: str, schema
+        self,
+        db: Session,
+        product_id: str,
+        current_user: User,
+        org_id: str,
+        schema,
     ):
         """Updates a product"""
 
@@ -113,7 +128,9 @@ class ProductService(Service):
         db.refresh(product)
         return product
 
-    def delete(self, db: Session, org_id: str, product_id: str, current_user: User):
+    def delete(
+        self, db: Session, org_id: str, product_id: str, current_user: User
+    ):
         """Deletes a product"""
 
         product: Product = self.fetch_single_by_organisation(
@@ -135,7 +152,8 @@ class ProductService(Service):
             for column, value in query_params.items():
                 if hasattr(Product, column) and value:
                     query = query.filter(
-                        getattr(Product, column).ilike(f"%{value}%"))
+                        getattr(Product, column).ilike(f"%{value}%")
+                    )
 
         return query.all()
 
@@ -179,11 +197,15 @@ class ProductService(Service):
                 .filter(Product.filter_status == filter_status.value)
                 .all()
             )
-            return [ProductFilterResponse.from_orm(product) for product in products]
+            return [
+                ProductFilterResponse.from_orm(product) for product in products
+            ]
         except Exception as e:
             raise
 
-    def fetch_by_status(self, db: Session, org_id: str, status: ProductStatusEnum):
+    def fetch_by_status(
+        self, db: Session, org_id: str, status: ProductStatusEnum
+    ):
         """Fetch products by filter status"""
         try:
             products = (
@@ -204,7 +226,10 @@ class ProductService(Service):
     ) -> dict:
         """Fetches the current stock level for a specific product"""
         product = self.fetch_single_by_organisation(
-            db=db, org_id=org_id, product_id=product_id, current_user=current_user
+            db=db,
+            org_id=org_id,
+            product_id=product_id,
+            current_user=current_user,
         )
 
         total_stock = product.quantity
@@ -216,14 +241,14 @@ class ProductService(Service):
         }
 
     def search_products(
-            db: Session,
-            org_id: str,
-            name: Optional[str] = None,
-            category: Optional[str] = None,
-            min_price: Optional[float] = None,
-            max_price: Optional[float] = None,
-            limit: int = 10,
-            page: int = 1,
+        db: Session,
+        org_id: str,
+        name: Optional[str] = None,
+        category: Optional[str] = None,
+        min_price: Optional[float] = None,
+        max_price: Optional[float] = None,
+        limit: int = 10,
+        page: int = 1,
     ):
 
         query = db.query(Product).filter(Product.org_id == org_id)
@@ -265,6 +290,32 @@ class ProductCategoryService(Service):
             )
 
         return new_category
+
+    @staticmethod
+    def update(db: Session, category: str, schema: ProductCategoryUpdate):
+        category = db.query(ProductCategory).filter_by(name=category).first()
+
+        if not category:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Category not found.",
+            )
+
+        # BASEMODEL.dict is deprecated
+        # update_data = schema.dict(exclude_unset=True)
+        update_data = schema.model_dump(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(category, key, value)
+
+        try:
+            db.commit()
+            db.refresh(category)
+        except sqlalchemy.exc.IntegrityError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Category already exists.",
+            )
+        return category
 
     @staticmethod
     def fetch_all(db: Session, **query_params: Optional[Any]):

--- a/api/v1/services/product.py
+++ b/api/v1/services/product.py
@@ -318,6 +318,19 @@ class ProductCategoryService(Service):
         return category
 
     @staticmethod
+    def delete(db: Session, category: str):
+        category = db.query(ProductCategory).filter_by(name=category).first()
+
+        if not category:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Category not found.",
+            )
+
+        db.delete(category)
+        db.commit()
+
+    @staticmethod
     def fetch_all(db: Session, **query_params: Optional[Any]):
         """Fetch all newsletter subscriptions with option to search using query parameters"""
 

--- a/tests/v1/product/test-update-product.py
+++ b/tests/v1/product/test-update-product.py
@@ -1,0 +1,84 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+from fastapi import HTTPException
+from api.v1.services.product import ProductCategoryService
+from api.v1.schemas.product import (
+    ProductCategoryRetrieve,
+)
+from api.v1.services.user import user_service
+from main import app
+
+CATEGORY_UPDATE_ENDPOINT = "/api/v1/products/categories/Category1"
+client = TestClient(app)
+
+
+def mock_deps():
+    return MagicMock(id="user_id")
+
+
+class TestUpdateProductCategory:
+
+    @classmethod
+    def setup_class(cls):
+        # Override dependency to simulate an authenticated user
+        app.dependency_overrides[user_service.get_current_user] = mock_deps
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Test updating an existing product category successfully
+    def test_update_product_category_successfully(self, mocker):
+        # Prepare the update payload (e.g., update the category name)
+        update_payload = {"name": "Updated Category1"}
+
+        # Simulate the updated category as returned by the service
+        updated_category = ProductCategoryRetrieve(
+            name="Updated Category1", id="1"
+        )
+
+        # Patch the update method of the ProductCategoryService to return the
+        # simulated updated category
+        mocker.patch.object(
+            ProductCategoryService, "update", return_value=updated_category
+        )
+
+        response = client.patch(
+            "/api/v1/products/categories/Category1", json=update_payload
+        )
+        assert response.status_code == 200
+        assert response.json()["data"] == {
+            "name": "Updated Category1",
+            "id": "1",
+        }
+        assert response.json()["message"] == "Category updated successfully"
+
+    # Test updating a non-existent product category
+    def test_update_product_category_not_found(self, mocker):
+        update_payload = {"name": "Updated Category2"}
+
+        # Patch the update method to raise a 404 HTTPException
+        def raise_not_found(*args, **kwargs):
+            raise HTTPException(status_code=404, detail="Category not found.")
+
+        mocker.patch.object(
+            ProductCategoryService, "update", side_effect=raise_not_found
+        )
+
+        response = client.patch(
+            "/api/v1/products/categories/NonExistentCategory",
+            json=update_payload,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Category not found."
+
+    # Test update when the user is unauthenticated
+    def test_update_product_category_unauthorized(self, mocker):
+        # Remove dependency override to simulate an unauthenticated request
+        app.dependency_overrides = {}
+
+        update_payload = {"name": "Updated Category1"}
+        response = client.patch(
+            "/api/v1/products/categories/Category1", json=update_payload
+        )
+        assert response.status_code == 401

--- a/tests/v1/product/test_delete_category.py
+++ b/tests/v1/product/test_delete_category.py
@@ -1,0 +1,66 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+from fastapi import HTTPException
+from api.v1.services.product import ProductCategoryService
+from api.v1.schemas.product import ProductCategoryRetrieve
+from api.v1.services.user import user_service
+from main import app
+
+CATEGORY_DELETE_ENDPOINT = "/api/v1/products/categories/Category1"
+client = TestClient(app)
+
+
+def mock_deps():
+    return MagicMock(id="user_id")
+
+
+class TestDeleteProductCategory:
+
+    @classmethod
+    def setup_class(cls):
+        # Override dependency to simulate an authenticated user
+        app.dependency_overrides[user_service.get_current_user] = mock_deps
+
+    @classmethod
+    def teardown_class(cls):
+        # Clear dependency overrides after tests
+        app.dependency_overrides = {}
+
+    # Test successful deletion of a product category
+    def test_delete_product_category_successfully(self, mocker):
+        # Create a mock deleted category object
+        deleted_category = ProductCategoryRetrieve(name="Category1", id="1")
+
+        # Patch the service method to return the mock deleted category
+        mocker.patch.object(
+            ProductCategoryService, "delete", return_value=deleted_category
+        )
+
+        response = client.delete("/api/v1/products/categories/Category1")
+        assert response.status_code == 204
+        assert response.json()["message"] == "Category deleted successfully"
+
+    # Test deletion when the category does not exist
+    def test_delete_product_category_not_found(self, mocker):
+        # Patch the delete method to simulate a non-existent category
+        def raise_not_found(*args, **kwargs):
+            raise HTTPException(status_code=404, detail="Category not found.")
+
+        mocker.patch.object(
+            ProductCategoryService, "delete", side_effect=raise_not_found
+        )
+
+        response = client.delete(
+            "/api/v1/products/categories/NonExistentCategory"
+        )
+        assert response.status_code == 404
+        # For HTTPException responses, FastAPI returns the error in a
+        # "message" field
+        assert response.json()["message"] == "Category not found."
+
+    # Test deletion when the user is unauthenticated
+    def test_delete_product_category_unauthorized(self, mocker):
+        # Remove dependency override to simulate an unauthenticated request
+        app.dependency_overrides = {}
+        response = client.delete("/api/v1/products/categories/Category1")
+        assert response.status_code == 401


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[FEAT]: Delete Product Category Endpoint using Unique Category Name

## Description

This PR introduces a delete endpoint for product categories, enabling the removal of a category by its name. The endpoint uses the DELETE method to locate a product category using its unique name, delete it from the database, and return a standardized success response. It also includes robust error handling for cases such as non-existent categories and authentication issues.

## Related Issue (Link to issue ticket)

#1129 

## Motivation and Context

Since product category names are unique, deleting a category by its name is both intuitive and efficient. This change simplifies the deletion process and ensures consistency in category management within the API.

## How Has This Been Tested?

- Unit tests have been written to cover:
  - Successful deletion of a product category.
  - Attempting to delete a non-existent category (expecting a 404 error).
  - Unauthorized deletion attempts (expecting a 401 error).
- Tests were executed using `pytest` and `pytest-mock` in a local development environment.
- The tests confirm that the endpoint returns a standardized success response on deletion and appropriate error responses for failure scenarios.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
