### PR TITLE
Feat/Endpoint for Testimonial Update for Authenticated users only

### DIFF
--- a/api/v1/routes/testimonial.py
+++ b/api/v1/routes/testimonial.py
@@ -6,8 +6,8 @@ from fastapi.encoders import jsonable_encoder
 from api.db.database import get_db
 from sqlalchemy.orm import Session
 from api.v1.models.user import User
-from fastapi import Depends, APIRouter, status,Query
-from api.utils.success_response import success_response
+from fastapi import Depends, APIRouter, status,Query, HTTPException
+from api.utils.success_response import success_response, fail_response
 from api.v1.services.testimonial import testimonial_service
 from api.v1.services.user import user_service
 from api.v1.schemas.testimonial import CreateTestimonial
@@ -76,6 +76,7 @@ async def delete_all_testimonials(
 
     testimonial_service.delete_all(db)
 
+
 @testimonial.post('/', response_model=success_response)
 def create_testimonial(
     testimonial_data: CreateTestimonial,
@@ -90,3 +91,32 @@ def create_testimonial(
         data={"id": testimonial.id}
     )
     return response
+
+
+@testimonial.put('/{testimonial_id}', response_model=success_response)
+def update_testimonial(
+    testimonial_id: str,
+    testimonial_data: CreateTestimonial,
+    db: Annotated[Session, Depends(get_db)],
+    current_user: User = Depends(user_service.get_current_user)
+):
+    '''Endpoint to update testimonial'''
+    testimonial = testimonial_service.fetch(db, testimonial_id)
+    if not testimonial:
+        return fail_response(
+            status_code=404,
+            message="Testimonial not found."
+        )
+
+    if testimonial.id != current_user.id:
+        return fail_response(
+            status_code=403,
+            message="Forbidden. unauthorized user access"
+        )
+
+    update_testimonial = testimonial_service.update(db, testimonial_id, testimonial_data)
+    return success_response(
+        status_code=200,
+        message="Your testimonial has been updated successfully.",
+        data={"id": update_testimonial.id}
+    )

--- a/api/v1/routes/testimonial.py
+++ b/api/v1/routes/testimonial.py
@@ -108,7 +108,7 @@ def update_testimonial(
             message="Testimonial not found."
         )
 
-    if testimonial.id != current_user.id:
+    if testimonial.author_id != current_user.id:
         return fail_response(
             status_code=403,
             message="Forbidden. unauthorized user access"

--- a/tests/v1/testimonial/test_update_testimonial.py
+++ b/tests/v1/testimonial/test_update_testimonial.py
@@ -64,9 +64,9 @@ def setup_access_token():
     global_access_token = user_response.json()["data"]["access_token"]
 
 
-def test_update_testimonial_success(db_session_mock):
-    db_session_mock.query().filter().first.return_value = data[0]
-    db_session_mock.commit.return_value = None
+def test_update_testimonial_success(mock_id):
+    mock_id.query().filter().first.return_value = data[0]
+    mock_id.commit.return_value = None
 
     update_data = {
         "content": "I love python (updated)",
@@ -79,11 +79,11 @@ def test_update_testimonial_success(db_session_mock):
     )
 
     assert response.status_code == 200
-    assert response.json()["messgae"] == "Your testimonial has been updated successfully."
+    assert response.json()["message"] == "Your testimonial has been updated successfully."
 
 
-def test_update_testimonial_not_found(db_session_mock):
-    db_session_mock.query().filter().first.return_value = None
+def test_update_testimonial_not_found(mock_id):
+    mock_id.query().filter().first.return_value = None
 
     update_data = {"content": "This is an updated testimonial."}
 
@@ -97,8 +97,8 @@ def test_update_testimonial_not_found(db_session_mock):
     assert response.json()["message"] == "Testimonial not found."
 
 
-def test_update_testimonial_unauthorized(db_session_mock):
-    db_session_mock.query().filter().first.return_value = data[0]
+def test_update_testimonial_unauthorized(mock_id):
+    mock_id.query().filter().first.return_value = data[0]
 
     update_data = {"content": "This is an updated testimonial."}
 

--- a/tests/v1/testimonial/test_update_testimonial.py
+++ b/tests/v1/testimonial/test_update_testimonial.py
@@ -50,7 +50,7 @@ def setup_access_token():
     user_response = client.post(
         "/api/v1/auth/register",
         json={
-            "password": "Testpassword",
+            "password": "2Testpassword",
             "first_name": "Test",
             "last_name": "User",
             "email": email,

--- a/tests/v1/testimonial/test_update_testimonial.py
+++ b/tests/v1/testimonial/test_update_testimonial.py
@@ -50,7 +50,7 @@ def setup_access_token():
     user_response = client.post(
         "/api/v1/auth/register",
         json={
-            "password": "2Testpassword",
+            "password": "@Testpassword2",
             "first_name": "Test",
             "last_name": "User",
             "email": email,

--- a/tests/v1/testimonial/test_update_testimonial.py
+++ b/tests/v1/testimonial/test_update_testimonial.py
@@ -1,0 +1,112 @@
+import pytest
+from main import app
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+from api.db.database import get_db
+import uuid
+
+client = TestClient(app)
+
+global_access_token = None
+
+data = [
+    {
+        "client_name": "firsttestclientname",
+        "author_id": "066a16d8-cab5-7dd3-8000-3a167556bb49",
+        "content": "I love python",
+        "id": "066a6e8b-f008-7242-8000-8f090997097c",
+        "updated_at": "2025-01-01T01:56:31.002967+01:00",
+        "client_designation": "testclient",
+        "comments": "I love testimonies",
+        "ratings": 5.02,
+        "created_at": "2025-01-01T01:56:31.002967+01:00",
+    }
+]
+
+
+"""Mocking the database"""
+
+
+@pytest.fixture
+def mock_db():
+    db_session = MagicMock()
+    yield db_session
+
+
+@pytest.fixture(autouse=True)
+def override_get_db(mock_db):
+    def get_db_override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = get_db_override
+    yield
+    app.dependency_overrides = {}
+
+
+@pytest.fixture(scope="module")
+def setup_access_token():
+    email = f"test{uuid.uuid4()}@gmail.com"
+    user_response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "password": "Testpassword",
+            "first_name": "Test",
+            "last_name": "User",
+            "email": email,
+        },
+    )
+    print("USER RESPONSE", user_response.json())
+
+    if user_response.status_code != 201:
+        raise Exception(f"Setup failed: {user_response.json()}")
+
+    global global_access_token
+    global_access_token = user_response.json()["data"]["access_token"]
+
+
+def test_update_testimonial_success(db_session_mock):
+    db_session_mock.query().filter().first.return_value = data[0]
+    db_session_mock.commit.return_value = None
+
+    update_data = {
+        "content": "I love python (updated)",
+    }
+
+    response = client.put(
+        f"/api/v1/testimonials/{data[0]['id']}",
+        json=update_data,
+        headers={"Authorization": f"Bearer {global_access_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["messgae"] == "Your testimonial has been updated successfully."
+
+
+def test_update_testimonial_not_found(db_session_mock):
+    db_session_mock.query().filter().first.return_value = None
+
+    update_data = {"content": "This is an updated testimonial."}
+
+    response = client.put(
+        "/api/v1/testimonials/non_existent_id",
+        json=update_data,
+        headers={"Authorization": f"Bearer {global_access_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["message"] == "Testimonial not found."
+
+
+def test_update_testimonial_unauthorized(db_session_mock):
+    db_session_mock.query().filter().first.return_value = data[0]
+
+    update_data = {"content": "This is an updated testimonial."}
+
+    response = client.put(
+        f"/api/v1/testimonials/{data[0]['id']}",
+        json=update_data,
+        headers={"Authorization": f"Bearer {global_access_token}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["message"] == "Forbidden. unauthorized user access"

--- a/tests/v1/testimonial/test_update_testimonial.py
+++ b/tests/v1/testimonial/test_update_testimonial.py
@@ -7,8 +7,6 @@ import uuid
 
 client = TestClient(app)
 
-global_access_token = None
-
 data = [
     {
         "client_name": "firsttestclientname",
@@ -25,12 +23,15 @@ data = [
 
 
 """Mocking the database"""
-
-
 @pytest.fixture
 def mock_db():
     db_session = MagicMock()
     yield db_session
+
+
+@pytest.fixture
+def mock_id(mock_db):
+    return mock_db
 
 
 @pytest.fixture(autouse=True)
@@ -55,18 +56,16 @@ def setup_access_token():
             "email": email,
         },
     )
-    print("USER RESPONSE", user_response.json())
 
     if user_response.status_code != 201:
         raise Exception(f"Setup failed: {user_response.json()}")
 
-    global global_access_token
-    global_access_token = user_response.json()["data"]["access_token"]
+    return user_response.json()["data"]["access_token"]
 
 
-def test_update_testimonial_success(mock_id):
+def test_update_testimonial_success(mock_id, setup_access_token):
     mock_id.query().filter().first.return_value = data[0]
-    mock_id.commit.return_value = None
+    mock_id.commit = MagicMock()
 
     update_data = {
         "content": "I love python (updated)",
@@ -75,22 +74,20 @@ def test_update_testimonial_success(mock_id):
     response = client.put(
         f"/api/v1/testimonials/{data[0]['id']}",
         json=update_data,
-        headers={"Authorization": f"Bearer {global_access_token}"},
+        headers={"Authorization": f"Bearer {setup_access_token}"},
     )
 
     assert response.status_code == 200
     assert response.json()["message"] == "Your testimonial has been updated successfully."
 
 
-def test_update_testimonial_not_found(mock_id):
+def test_update_testimonial_not_found(mock_id, setup_access_token):
     mock_id.query().filter().first.return_value = None
-
-    update_data = {"content": "This is an updated testimonial."}
 
     response = client.put(
         "/api/v1/testimonials/non_existent_id",
-        json=update_data,
-        headers={"Authorization": f"Bearer {global_access_token}"},
+        json={"content": "This is an updated testimonial."},
+        headers={"Authorization": f"Bearer {setup_access_token}"},
     )
 
     assert response.status_code == 404
@@ -98,14 +95,10 @@ def test_update_testimonial_not_found(mock_id):
 
 
 def test_update_testimonial_unauthorized(mock_id):
-    mock_id.query().filter().first.return_value = data[0]
-
-    update_data = {"content": "This is an updated testimonial."}
-
     response = client.put(
         f"/api/v1/testimonials/{data[0]['id']}",
-        json=update_data,
-        headers={"Authorization": f"Bearer {global_access_token}"},
+        json={"content": "This is an updated testimonial."},
+        headers={"Authorization": "Bearer invalid_token"},
     )
 
     assert response.status_code == 403


### PR DESCRIPTION
### Description
Create an endpoint that allows authenticated users to update user testimonials, ensuring accurate and up-to-date feedback on the platform.

## Related Issue (Link to issue ticket)
https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1154


## Motivation and Context
This chance is requried to ensure users can be able to update their information in the testimonials. Allowing them to correct and edit testimonials.

## How Has This Been Tested?
This feature has been tested using:
- Unit tests with FastAPI's `TestClient` using `pytest`
- Mocking database queries to simulate different scenarios (successful upate, unathorized access, non-existing testimonials)
- Manual testing using Postman, sending request with different authenticated states

## Screenshots (if appropriate - Postman, etc):

​

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
