### PR TITLE
fix: server crashes on login if password is not provided in the request payload

### DIFF
--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -252,6 +252,9 @@ class LoginRequest(BaseModel):
         email = values.get("email")
         totp_code = values.get("totp_code")
 
+        if not password:
+            return values
+
         # constraints for password
         if not any(c.islower() for c in password):
             raise ValueError("password must include at least one lowercase character")

--- a/api/v1/schemas/user.py
+++ b/api/v1/schemas/user.py
@@ -5,12 +5,15 @@ from typing import (Optional, Union,
                     List, Annotated, Dict,
                     Literal)
 
-from pydantic import (BaseModel, EmailStr,
-                      field_validator, ConfigDict,
-                      StringConstraints,
-                      model_validator)
-                      
-from pydantic import Field  # Added this import
+from pydantic import (
+    BaseModel,
+    EmailStr,
+    field_validator,
+    ConfigDict,
+    StringConstraints,
+    model_validator,
+    Field
+)
 
 def validate_mx_record(domain: str):
     """

--- a/tests/v1/auth/test_signin.py
+++ b/tests/v1/auth/test_signin.py
@@ -244,6 +244,23 @@ class TestUserLogin:
         assert response_json.get("status_code") == 422
         assert response_json.get("message") == "Invalid input" or "Invalid" in response_json.get("message", "")
 
+    def test_user_login_failure_without_password(self, monkeypatch):
+        """Test login failure when password is not provided"""
+
+        monkeypatch.setattr(
+            user_service,
+            "authenticate_user",
+            lambda db, email, password: self.mock_user
+        )
+
+        response = self.client.post(
+            "/api/v1/auth/login",
+            json={"email": "testuser1@gmail.com"},
+        )
+        response_json = response.json()
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response_json.get("message") == "Invalid input"
 
 # Mock the database dependency
 @pytest.fixture


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This pr addrresses the issue in `/api/v1/auth/login` where the server crashes if the password field is not provided in the request payload. It also does a minor refactor where it combines two import statements into one in `users.schemas`

​

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Fix: Server crashes on login if password is not provided in the request payload](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1209)

​

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
🚀 Stability: Prevents unnecessary server crashes due to missing input.
🔍 Proper Validation: Ensures the API returns a 422 Unprocessable Entity error for missing passwords.
🔐 Security Fix: Prevents exposing stack traces or internal errors due to unhandled missing input.

​

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I wrote unit tests to automatically test the fix works as expected
- I also tested it manually on postman and got the expected response
​

## Screenshots (if appropriate - Postman, etc):

​
<img width="969" alt="Screenshot 2025-03-01 at 11 06 21 PM" src="https://github.com/user-attachments/assets/362abee2-4e75-420e-815c-11f0e33e4449" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
