### PR TITLE
soft delete retested getblog adjusted with filter

### DIFF
--- a/api/utils/pagination.py
+++ b/api/utils/pagination.py
@@ -69,8 +69,13 @@ def paginated_response(
     if filters and join is None:
         # Apply filters
         for attr, value in filters.items():
+            
             if value is not None:
-                query = query.filter(getattr(model, attr).like(f"%{value}%"))
+                column = getattr(model, attr)
+                if isinstance(value, bool):
+                    query = query.filter(column == value)
+                else:
+                    query = query.filter(column.like(f"%{value}%"))
 
     elif filters and join is not None:
         # Apply filters

--- a/api/utils/pagination.py
+++ b/api/utils/pagination.py
@@ -89,10 +89,7 @@ def paginated_response(
     results = jsonable_encoder(query.offset(skip).limit(limit).all())
     total_pages = int(total / limit) + (total % limit > 0)
 
-    return success_response(
-        status_code=200,
-        message="Successfully fetched items",
-        data={
+    return {
             "pages": total_pages,
             "total": total,
             "skip": skip,
@@ -107,4 +104,4 @@ def paginated_response(
                 }
             )
         }
-    )
+    

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -224,7 +224,7 @@ async def archive_blog_post(
     """Endpoint to archive/soft-delete a blog post"""
 
     blog_service = BlogService(db=db)
-    blog_post = blog_service.fetch(blog_id=id)
+    blog_post = blog_service.fetch(blog_id=blog_id)
     if not blog_post:
         raise HTTPException(status_code=404, detail="Post not found")
     #check if admin/ authorized user

--- a/api/v1/routes/blog.py
+++ b/api/v1/routes/blog.py
@@ -52,7 +52,20 @@ def create_blog(
 def get_all_blogs(db: Session = Depends(get_db), limit: int = 10, skip: int = 0):
     """Endpoint to get all blogs"""
 
-    return paginated_response(
+    blog = paginated_response(
+        db=db,
+        model=Blog,
+        limit=limit,
+        skip=skip,
+    )
+
+    return success_response(200, message="Successfully fetched all blogs", data=blog)
+
+@blog.get("/active", response_model=success_response)
+def get_all_active_blogs(db: Session = Depends(get_db), limit: int = 10, skip: int = 0):
+    """Endpoint to get all active blogs"""
+
+    blog = paginated_response(
         db=db,
         model=Blog,
         limit=limit,
@@ -60,6 +73,7 @@ def get_all_blogs(db: Session = Depends(get_db), limit: int = 10, skip: int = 0)
         filters={"is_deleted": False} #filter out soft-deleted blogs
     )
 
+    return success_response(200, message="Successfully fetched active blogs", data=blog)
 
 @blog.get("/{id}", response_model=BlogPostResponse)
 def get_blog_by_id(id: str, db: Session = Depends(get_db)):
@@ -109,6 +123,8 @@ async def update_blog(
         status_code=200,
         data=jsonable_encoder(updated_blog_post),
     )
+
+
 
 
 @blog.post("/{blog_id}/like", response_model=BlogLikeDislikeResponse)
@@ -237,6 +253,34 @@ async def archive_blog_post(
 
     return success_response(
         message="Blog post archived successfully!",
+        status_code=200,
+        data=jsonable_encoder(blog_post),
+    )
+
+@blog.put("/{blog_id}/restore")
+async def restore_blog_post(
+    blog_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(user_service.get_current_super_admin),
+):
+    
+    """Endpoint to restore a soft-deleted blog post"""
+
+    blog_service = BlogService(db=db)
+    blog_post = blog_service.fetch(blog_id=blog_id)
+    if not blog_post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    #check if admin/ authorized user
+    if not (blog_post.author_id != current_user.id or current_user.is_superadmin):
+        raise HTTPException(status_code=403, detail="You don't have permission to perform this action")
+    if not blog_post.is_deleted:
+        raise HTTPException(status_code=400, detail="Blog post is already active")
+    blog_post.is_deleted = False
+    db.commit()
+    db.refresh(blog_post)
+
+    return success_response(
+        message="Blog post restored successfully!",
         status_code=200,
         data=jsonable_encoder(blog_post),
     )

--- a/tests/v1/blog/test_restore_blog.py
+++ b/tests/v1/blog/test_restore_blog.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.db.database import get_db
+from api.v1.services.user import user_service
+from api.v1.models import User
+from api.v1.models.blog import Blog
+from main import app
+
+
+def mock_get_db():
+    db_session = MagicMock()
+    yield db_session
+
+
+def mock_get_current_super_admin():
+    return User(id="1", is_superadmin=True)
+
+@pytest.fixture
+def db_session_mock():
+    db_session = MagicMock(spec=Session)
+    return db_session
+
+@pytest.fixture
+def client(db_session_mock):
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    client = TestClient(app)
+    yield client
+    
+
+def test_restore_blog_success(client, db_session_mock):
+    '''Test for success in blog archiving'''
+
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: mock_get_current_super_admin()
+    blog_id = uuid7()
+    mock_blog = Blog(id=blog_id, title="Test Blog",
+                     content="Test Content", is_deleted=True)
+
+    db_session_mock.query(Blog).filter(Blog.id==blog_id).first.return_value = mock_blog
+
+    response = client.put(f"/api/v1/blogs/{mock_blog.id}/restore", headers={'Authorization': 'Bearer token'})
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Blog post restored successfully!"
+
+    
+def test_restore_blog_not_found(client, db_session_mock):
+    '''test for blog not found'''
+
+    db_session_mock.query(Blog).filter(Blog.id == f'{uuid7()}').first.return_value = None
+
+    app.dependency_overrides[get_db] = lambda: db_session_mock
+    app.dependency_overrides[user_service.get_current_super_admin] = lambda: mock_get_current_super_admin
+
+    response = client.put(f"/api/v1/blogs/{uuid7()}/restore", headers={'Authorization': 'Bearer token'})
+
+    assert response.status_code == 404
+    assert response.json()["message"] == "Post not found"
+    
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
<!--- Added a soft delete feature to blog app -->

## Description
<!--- With the soft delete endpoint, previously deleted blog posts can be retrieve. 
The get_all_blogs endpoint too was also adjusted to put into consideration archived/soft-deleted post by implementing the filter "is_deleted":False-->

## Related Issue [FEAT[auth]: add soft_delete endpoint to the blog app](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1013)(#1013 )
​
<!---Unlike the hard delete that totally loses the deleted post, soft delete archives the said post incase there is a future intention to restore it -->

## How Has This Been Tested?
<!---It has been tested with a pytest "test_archived_blog" created and "pytest tests/v1/blog" to test that the changes made did not fail exisitng test-->

## Screenshots:
![image_2025-02-28_152100055](https://github.com/user-attachments/assets/28bcda5d-0f97-4b3f-adea-be954a7f718c)
![image_2025-03-02_141400239](https://github.com/user-attachments/assets/91ba2ea5-3b1a-4dca-9309-66fc0289e250)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
