### PR TITLE
Change password request from put to post  request

### DIFF
--- a/api/v1/routes/auth.py
+++ b/api/v1/routes/auth.py
@@ -368,7 +368,7 @@ async def verify_magic_link(request: Request, token_schema: Token, db: Session =
     return response
 
 
-@auth.put("/password", status_code=200)
+@auth.post("/password", status_code=200)
 @limiter.limit("1000/minute")  # Limit to 1000 requests per minute per IP
 async def change_password(
     request: Request, 


### PR DESCRIPTION
Change password request from put to post  request

​

## Description

This pull request updates the change password API route in api/v1/routes/auth.py to follow RESTful best practices. Previously, the route used PUT, which is intended for idempotent updates. However, changing a password is an action-based operation, making POST the more appropriate HTTP method.

​

## Related Issue (Link to issue ticket)

https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/issues/1238

​

## Motivation and Context

The current `PUT` method is inconsistent with common REST API convention.  
- `POST` is preferred for actions like password changes, which are not idempotent.
- `POST` signals to integrators that this is a special action, not a regular update.
- This change also aligns with **security best practices** for sensitive operations like password changes.


​

## How Has This Been Tested?

I wrote unit tests to automatically test the fix works as expected
I also tested it manually on postman and got the expected response
​
​

## Screenshots (if appropriate - Postman, etc):

​

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
