### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/api/v1/routes/jobs.py
+++ b/api/v1/routes/jobs.py
@@ -317,9 +317,10 @@ async def create_bookmark(
             "data": {}
         }
     except Exception as e:
+        logger.error(f"An unexpected error occurred: {e}", exc_info=True)
         return {
         "status": "failure",
-        "message": str(e),
+        "message": "An internal error has occurred. Please try again later.",
         "status_code": 500,
         "data": {}
     }


### PR DESCRIPTION
Potential fix for [https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/security/code-scanning/7](https://github.com/hngprojects/hng_boilerplate_python_fastapi_web/security/code-scanning/7)

To fix the issue, the code should be updated to ensure that exceptions are logged internally for debugging purposes, while a generic error message is returned to the user. This approach prevents sensitive information from being exposed externally while still allowing developers to diagnose issues using server-side logs.

**Steps to fix:**
1. Replace the direct use of `str(e)` in the response with a generic error message.
2. Log the exception details (including stack trace) using the `logger` utility for internal debugging.
3. Ensure that the user-facing error message does not reveal any sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
